### PR TITLE
UI/UX improvements

### DIFF
--- a/HuntBuddy/Configuration.cs
+++ b/HuntBuddy/Configuration.cs
@@ -8,6 +8,7 @@ namespace HuntBuddy
 	{
 		public int Version { get; set; }
 
+		public bool LockWindowPositions;
 		public bool ShowLocalHunts;
 		public bool ShowLocalHuntIcons;
 		public bool HideLocalHuntBackground;

--- a/HuntBuddy/Interface.cs
+++ b/HuntBuddy/Interface.cs
@@ -93,7 +93,7 @@ namespace HuntBuddy
 						         return treeOpen;
 					         }))
 				{
-					ImGui.Indent();
+					//ImGui.Indent();
 					foreach (var mobHuntEntry in entry.Value)
 					{
 						if (Location.Database.ContainsKey(mobHuntEntry.MobHuntId))
@@ -199,7 +199,7 @@ namespace HuntBuddy
 						}
 					}
 
-					ImGui.Unindent();
+					//ImGui.Unindent();
 					ImGui.TreePop();
 				}
 

--- a/HuntBuddy/Interface.cs
+++ b/HuntBuddy/Interface.cs
@@ -123,7 +123,7 @@ namespace HuntBuddy
 							if (ImGui.IsItemHovered())
 							{
 								ImGui.BeginTooltip();
-								ImGui.Text("Show hunt location on the map");
+								ImGui.Text("Show hunt area on the map");
 								ImGui.EndTooltip();
 							}
 
@@ -278,7 +278,7 @@ namespace HuntBuddy
 					if (ImGui.IsItemHovered())
 					{
 						ImGui.BeginTooltip();
-						ImGui.Text("Show hunt location on the map");
+						ImGui.Text("Show hunt area on the map");
 						ImGui.EndTooltip();
 					}
 

--- a/HuntBuddy/Interface.cs
+++ b/HuntBuddy/Interface.cs
@@ -24,7 +24,14 @@ namespace HuntBuddy
 
 			ImGui.SetNextWindowSize(new Vector2(400 * ImGui.GetIO().FontGlobalScale, 500), ImGuiCond.Once);
 
-			if (!ImGui.Begin($"{this.plugin.Name}", ref draw, ImGuiWindowFlags.NoDocking))
+			var windowFlags = ImGuiWindowFlags.NoDocking;
+
+			if (this.plugin.Configuration.LockWindowPositions)
+			{
+				windowFlags |= ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove;
+			}
+
+			if (!ImGui.Begin($"{this.plugin.Name}", ref draw, windowFlags))
 			{
 				return draw;
 			}
@@ -230,6 +237,11 @@ namespace HuntBuddy
 				windowFlags |= ImGuiWindowFlags.NoBackground;
 			}
 
+			if (this.plugin.Configuration.LockWindowPositions)
+			{
+				windowFlags |= ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove;
+			}
+
 			if (!ImGui.Begin("Hunts in current area", windowFlags))
 			{
 				return;
@@ -320,13 +332,21 @@ namespace HuntBuddy
 		{
 			ImGui.SetNextWindowSize(Vector2.Zero, ImGuiCond.Always);
 
-			if (!ImGui.Begin($"{this.plugin.Name} settings", ImGuiWindowFlags.NoDocking))
+			var windowFlags = ImGuiWindowFlags.NoDocking;
+
+			if (this.plugin.Configuration.LockWindowPositions)
+			{
+				windowFlags |= ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove;
+			}
+
+			if (!ImGui.Begin($"{this.plugin.Name} settings", windowFlags))
 			{
 				return;
 			}
 
 			var save = false;
 
+			save |= ImGui.Checkbox("Lock plugin window positions", ref this.plugin.Configuration.LockWindowPositions);
 			save |= ImGui.Checkbox("Show hunts in local area", ref this.plugin.Configuration.ShowLocalHunts);
 			save |= ImGui.Checkbox(
 				"Show icons of hunts in local area",

--- a/HuntBuddy/Plugin.cs
+++ b/HuntBuddy/Plugin.cs
@@ -144,13 +144,18 @@ namespace HuntBuddy
 		}
 
 		[Command("/phb")]
-		[HelpMessage("Toggles UI\nArguments:\nreload - Reloads data")]
+		[HelpMessage("Toggles UI\nArguments:\nreload - Reloads data\nlocal - Toggles the local hunt marks window")]
 		public void PluginCommand(string command, string args)
 		{
 			if (args == "reload")
 			{
 				this.MobHuntEntriesReady = false;
 				Task.Run(this.ReloadData);
+			}
+			else if (args == "local")
+			{
+				this.Configuration.ShowLocalHunts = !this.Configuration.ShowLocalHunts;
+				this.Configuration.Save();
 			}
 			else
 			{


### PR DESCRIPTION
Changes made:
- There are two buttons to locate the hunt mark on your map. One shows a radius for the approximate area, one shows only a map marker, but both used the same tooltips, which could be confusing for new users. The button that includes the radius now says "show hunt _area_ on the map" while the one with only a single marker still uses the word "location" as before.
- There's a new subcommand argument `local` to toggle the display of the local map zone's hunt targets window, instead of needing to open the main window, open the configuration, toggle the box, and close the configuration.
- The ability to lock window size/position was implemented to prevent accidentally moving the windows while attempting to click on the controls.
- The main window's tree display of hunt marks per zone no longer indents the line with the mob name and utility buttons, reducing the required width of the window for people who keep it narrower to conserve space or fit their UI layout. It should still be clear that those lines are children of the relevant tree node thanks to the utility buttons. If this is not desired, it should be easy to revert, since the relevant two lines in `Interface.cs` ([96](https://github.com/SheepGoMeh/HuntBuddy/blob/4e0352e5d20e4450a66c6326c38250499d9f4e4e/HuntBuddy/Interface.cs#L96) and [202](https://github.com/SheepGoMeh/HuntBuddy/blob/4e0352e5d20e4450a66c6326c38250499d9f4e4e/HuntBuddy/Interface.cs#L202)) were only commented out, not deleted.

Changes planned:
- The two buttons to locate the mobs on the map can be condensed into one that performs a configurable default of either marker-and-area or marker-only, and perform the alternate action when `shift` is held while clicking. This will conserve more screen space and allow people to ignore the mode that they rarely/never use while still allowing everyone to select their preference and access the alternative with ease.