### PR TITLE
Update local hunt buttons to match main window ones

### DIFF
--- a/HuntBuddy/Interface.cs
+++ b/HuntBuddy/Interface.cs
@@ -278,38 +278,39 @@ namespace HuntBuddy
 
 					ImGui.SameLine();
 
-					if (Interface.IconButton(FontAwesomeIcon.Compass, $"openRadius##{mobHuntEntry.MobHuntId}"))
+					if (Interface.IconButton(FontAwesomeIcon.MapMarkedAlt, $"open##{mobHuntEntry.MobHuntId}"))
 					{
+						var includeArea = this.plugin.Configuration.IncludeAreaOnMap;
+						if (ImGui.IsKeyDown(ImGuiKey.ModShift))
+						{
+							includeArea = !includeArea;
+						}
 						Location.CreateMapMarker(
 							mobHuntEntry.TerritoryType,
 							mobHuntEntry.MapId,
 							mobHuntEntry.MobHuntId,
 							mobHuntEntry.Name,
-							Location.OpenType.ShowOpen);
+							includeArea ? Location.OpenType.ShowOpen : Location.OpenType.MarkerOpen);
 					}
 
 					if (ImGui.IsItemHovered())
 					{
+						var color = ImGui.IsKeyDown(ImGuiKey.ModShift) ? new Vector4(0f, 0.7f, 0f, 1f) : new Vector4(0.7f, 0.7f, 0.7f, 1f);
 						ImGui.BeginTooltip();
-						ImGui.Text("Show hunt area on the map");
-						ImGui.EndTooltip();
-					}
-
-					ImGui.SameLine();
-
-					if (Interface.IconButton(FontAwesomeIcon.MapMarkedAlt, $"open##{mobHuntEntry.MobHuntId}"))
-					{
-						Location.CreateMapMarker(
-							mobHuntEntry.TerritoryType,
-							mobHuntEntry.MapId,
-							mobHuntEntry.MobHuntId,
-							mobHuntEntry.Name);
-					}
-
-					if (ImGui.IsItemHovered())
-					{
-						ImGui.BeginTooltip();
-						ImGui.Text("Show hunt location on the map");
+						if (this.plugin.Configuration.IncludeAreaOnMap)
+						{
+							ImGui.Text("Show hunt area on the map");
+							ImGui.TextColored(
+								color,
+								"Hold [SHIFT] to show the location only");
+						}
+						else
+						{
+							ImGui.Text("Show hunt location on the map");
+							ImGui.TextColored(
+								color,
+								"Hold [SHIFT] to include the area");
+						}
 						ImGui.EndTooltip();
 					}
 


### PR DESCRIPTION
When I made the changes to the interface buttons to merge the show-hunt-area and show-hunt-location buttons into one, I forgot to apply the same change to the local hunts window. This fixes that by cloning the changes into `Interface.DrawLocalHunts()` as well.