### PR TITLE
Fix list command

### DIFF
--- a/HuntBuddy/Plugin.cs
+++ b/HuntBuddy/Plugin.cs
@@ -222,7 +222,7 @@ namespace HuntBuddy
 							break;
 						}
 						foreach (string expac in this.MobHuntEntries.Keys) {
-							Chat.Print($"{expac}: {string.Join(", ", this.MobHuntEntries[expac].Values.SelectMany(e => e).OrderBy(s => s.Name))}");
+							Chat.Print($"{expac}: {string.Join(", ", this.MobHuntEntries[expac].Values.SelectMany(e => e).OrderBy(s => s.Name).Select(m => m.Name))}");
 						}
 						break;
 					default:


### PR DESCRIPTION
Hey! I pulled down the latest changed and tried them out locally but when I ran `/phb list` I got the following output

```
Endwalker: HuntBuddy.MobHuntEntry, HuntBuddy.MobHuntEntry, HuntBuddy.MobHuntEntry...
````

Looks like the` OrderBy()` still returns a `IOrderedEnumerable `of `MobHuntEntry`. So added a `Select() `after it to map each entry to it's name. After that change I'm getting the output as expected.
```
Endwalker: Akantha, Akyaali Crab, Almasty, Armalcolite, Automated Bit, Dynamite, Genomos, Manjusaka, Regolith, Stellar Amphiptere, Trimmer, Troll, Ufiti, Valras...
```
