### PR TITLE
Create IPC integration with XivEsp to more easily find mobs

### DIFF
--- a/HuntBuddy/Configuration.cs
+++ b/HuntBuddy/Configuration.cs
@@ -11,6 +11,8 @@ public class Configuration: IPluginConfiguration {
 		set;
 	}
 
+	public bool EnableXivEspIntegration;
+	public bool AutoSetEspSearchOnNextHuntCommand;
 	public bool IncludeAreaOnMap;
 	public bool LockWindowPositions;
 	public bool ShowLocalHunts;

--- a/HuntBuddy/DalamudPackager.targets
+++ b/HuntBuddy/DalamudPackager.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-    <Target Name="PackagePlugin" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+    <Target Name="PackagePlugin" AfterTargets="Build">
         <DalamudPackager
                 ProjectDir="$(ProjectDir)"
                 OutputPath="$(OutputPath)"

--- a/HuntBuddy/Ipc/ConsumerBase.cs
+++ b/HuntBuddy/Ipc/ConsumerBase.cs
@@ -7,16 +7,24 @@ using System.Threading.Tasks;
 namespace HuntBuddy.Ipc;
 public abstract class ConsumerBase {
 	public const int MS_PER_AVAILABILITY_RECHECK = 5000;
+
+	public abstract string RequiredPlugin { get; }
+
 	private bool isAvailable;
 	private long timeSinceLastCheck;
 
 	public bool IsAvailable {
 		get {
 			if (Environment.TickCount64 > this.timeSinceLastCheck + MS_PER_AVAILABILITY_RECHECK) {
-				try {
-					this.isAvailable = this.Validate();
+				if (Service.PluginInterface.InstalledPlugins.Any(p => p.IsLoaded && p.InternalName == this.RequiredPlugin)) {
+					try {
+						this.isAvailable = this.Validate();
+					}
+					catch {
+						this.isAvailable = false;
+					}
 				}
-				catch {
+				else {
 					this.isAvailable = false;
 				}
 				this.timeSinceLastCheck = Environment.TickCount64;

--- a/HuntBuddy/Ipc/ConsumerBase.cs
+++ b/HuntBuddy/Ipc/ConsumerBase.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HuntBuddy.Ipc;
+public abstract class ConsumerBase {
+	public const int MS_PER_AVAILABILITY_RECHECK = 5000;
+	private bool isAvailable;
+	private long timeSinceLastCheck;
+
+	public bool IsAvailable {
+		get {
+			if (Environment.TickCount64 > this.timeSinceLastCheck + MS_PER_AVAILABILITY_RECHECK) {
+				try {
+					this.isAvailable = this.Validate();
+				}
+				catch {
+					this.isAvailable = false;
+				}
+				this.timeSinceLastCheck = Environment.TickCount64;
+			}
+
+			return this.isAvailable;
+		}
+	}
+
+	protected abstract bool Validate();
+}

--- a/HuntBuddy/Ipc/EspConsumer.cs
+++ b/HuntBuddy/Ipc/EspConsumer.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+using Dalamud.Plugin.Ipc;
+
+namespace HuntBuddy.Ipc;
+
+public class EspConsumer: ConsumerBase {
+	public override string RequiredPlugin { get; } = "XivEsp";
+	protected override bool Validate() {
+		this.getUnifiedSearch.InvokeFunc();
+		return true;
+	}
+
+	private ICallGateSubscriber<string> getUnifiedSearch = null!;
+	private ICallGateSubscriber<string, object> setSubstringSearch = null!;
+
+	private void Subscribe() {
+		try {
+			this.getUnifiedSearch = Service.PluginInterface.GetIpcSubscriber<string>("XivEsp.GetSearch");
+			this.setSubstringSearch = Service.PluginInterface.GetIpcSubscriber<string, object>("XivEsp.SetSubstring");
+		}
+		catch (Exception ex) {
+			Service.PluginLog.Debug($"Failed to subscribe to XivEsp\nReason: {ex}");
+		}
+	}
+
+	public EspConsumer() => this.Subscribe();
+
+	public bool CanSetSearch {
+		get {
+			try {
+				string current = this.getUnifiedSearch.InvokeFunc();
+				char type = current[0];
+				return type is 'N' or 'S';
+			}
+			catch {
+				return false;
+			}
+		}
+	}
+	public bool SearchFor(string target) {
+		try {
+			if (this.CanSetSearch) {
+				this.setSubstringSearch.InvokeAction(target);
+				return true;
+			}
+			else {
+				Service.Chat.Print("Cannot override complex (glob/regex) XivEsp search");
+				return false;
+			}
+		}
+		catch (Exception ex) {
+			Service.PluginLog.Error($"XivEsp is not responding to IPC: {ex}");
+			Service.Chat.PrintError("XivEsp plugin is not responding");
+			return false;
+		}
+	}
+}

--- a/HuntBuddy/Ipc/TeleportConsumer.cs
+++ b/HuntBuddy/Ipc/TeleportConsumer.cs
@@ -5,6 +5,7 @@ using Dalamud.Plugin.Ipc;
 namespace HuntBuddy.Ipc;
 
 public class TeleportConsumer: ConsumerBase {
+	public override string RequiredPlugin { get; } = "TeleporterPlugin";
 	protected override bool Validate() {
 		this.consumerMessageSetting.InvokeFunc();
 		return true;

--- a/HuntBuddy/Ipc/TeleportConsumer.cs
+++ b/HuntBuddy/Ipc/TeleportConsumer.cs
@@ -4,27 +4,10 @@ using Dalamud.Plugin.Ipc;
 
 namespace HuntBuddy.Ipc;
 
-public class TeleportConsumer {
-	private bool isAvailable;
-	private long timeSinceLastCheck;
-
-	public bool IsAvailable {
-		get {
-			if (this.timeSinceLastCheck + 5000 > Environment.TickCount64) {
-				return this.isAvailable;
-			}
-
-			try {
-				this.consumerMessageSetting.InvokeFunc();
-				this.isAvailable = true;
-				this.timeSinceLastCheck = Environment.TickCount64;
-			}
-			catch {
-				this.isAvailable = false;
-			}
-
-			return this.isAvailable;
-		}
+public class TeleportConsumer: ConsumerBase {
+	protected override bool Validate() {
+		this.consumerMessageSetting.InvokeFunc();
+		return true;
 	}
 
 	private ICallGateSubscriber<bool> consumerMessageSetting = null!;

--- a/HuntBuddy/Windows/ConfigurationWindow.cs
+++ b/HuntBuddy/Windows/ConfigurationWindow.cs
@@ -32,6 +32,15 @@ public class ConfigurationWindow: Window {
 	public override void Draw() {
 		bool save = false;
 
+		ImGui.BeginDisabled(Plugin.EspConsumer?.IsAvailable == false);
+		save |= ImGui.Checkbox("Enable XivEsp plugin integration?", ref Plugin.Instance.Configuration.EnableXivEspIntegration);
+		ImGui.Indent();
+		save |= ImGui.Checkbox("Set XivEsp search when using '/phb next' command?", ref Plugin.Instance.Configuration.AutoSetEspSearchOnNextHuntCommand);
+		ImGui.Unindent();
+		ImGui.EndDisabled();
+
+		ImGui.Spacing();
+
 		save |= ImGui.Checkbox("Lock plugin window positions", ref Plugin.Instance.Configuration.LockWindowPositions);
 		save |= ImGui.Checkbox("Include hunt area on map by default",
 			ref Plugin.Instance.Configuration.IncludeAreaOnMap);

--- a/HuntBuddy/Windows/LocalHuntsWindow.cs
+++ b/HuntBuddy/Windows/LocalHuntsWindow.cs
@@ -14,7 +14,7 @@ namespace HuntBuddy.Windows;
 /// Local hunts window.
 /// </summary>
 public class LocalHuntsWindow: Window {
-	public LocalHuntsWindow(): base(
+	public LocalHuntsWindow() : base(
 		"Hunts in current area",
 		ImGuiWindowFlags.NoNavInputs | ImGuiWindowFlags.NoDocking,
 		true) {
@@ -46,12 +46,10 @@ public class LocalHuntsWindow: Window {
 		}
 	}
 
-	public override unsafe bool DrawConditions() =>
-		Plugin.Instance.Configuration.ShowLocalHunts &&
-		!Plugin.Instance.CurrentAreaMobHuntEntries.IsEmpty &&
-		Plugin.Instance.CurrentAreaMobHuntEntries.Count(
-			x => Plugin.Instance.MobHuntStruct->CurrentKills[x.CurrentKillsOffset] == x.NeededKills) !=
-		Plugin.Instance.CurrentAreaMobHuntEntries.Count;
+	public override unsafe bool DrawConditions() => Plugin.Instance.Configuration.ShowLocalHunts
+		&& !Plugin.Instance.CurrentAreaMobHuntEntries.IsEmpty
+		&& Plugin.Instance.CurrentAreaMobHuntEntries
+			.Count(x => Plugin.Instance.MobHuntStruct->CurrentKills[x.CurrentKillsOffset] == x.NeededKills) != Plugin.Instance.CurrentAreaMobHuntEntries.Count;
 
 	public override unsafe void Draw() {
 		foreach (MobHuntEntry? mobHuntEntry in Plugin.Instance.CurrentAreaMobHuntEntries) {
@@ -112,6 +110,20 @@ public class LocalHuntsWindow: Window {
 					}
 
 					ImGui.EndTooltip();
+				}
+
+				if (Plugin.Instance.Configuration.EnableXivEspIntegration && Plugin.EspConsumer?.IsAvailable == true) {
+
+					ImGui.SameLine();
+					if (InterfaceUtil.IconButton(FontAwesomeIcon.Search, $"esp##{mobHuntEntry.MobHuntId}")) {
+						Plugin.EspConsumer.SearchFor(mobHuntEntry.Name!);
+					}
+
+					if (ImGui.IsItemHovered()) {
+						ImGui.BeginTooltip();
+						ImGui.Text("Set XivEsp search to this target");
+						ImGui.EndTooltip();
+					}
 				}
 
 				ImGui.SameLine();

--- a/HuntBuddy/Windows/MainWindow.cs
+++ b/HuntBuddy/Windows/MainWindow.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 using Dalamud.Interface;
 using Dalamud.Interface.Windowing;
 
-using ImGuiNET;
-
 using HuntBuddy.Utils;
+
+using ImGuiNET;
 
 namespace HuntBuddy.Windows;
 
@@ -16,7 +16,7 @@ namespace HuntBuddy.Windows;
 /// Main plugin window.
 /// </summary>
 public class MainWindow: Window {
-	public MainWindow(): base(
+	public MainWindow() : base(
 		$"{Plugin.Instance.Name}",
 		ImGuiWindowFlags.NoDocking,
 		true) {
@@ -59,30 +59,26 @@ public class MainWindow: Window {
 			Plugin.Instance.OpenConfigUi();
 		}
 
-		foreach (KeyValuePair<string, Dictionary<KeyValuePair<uint, string>, List<MobHuntEntry>>> expansionEntry in
-		         Plugin.Instance.MobHuntEntries.Where(
-			         expansionEntry =>
-				         ImGui.TreeNode(expansionEntry.Key))) {
-			foreach (KeyValuePair<KeyValuePair<uint, string>, List<MobHuntEntry>> entry in expansionEntry.Value.Where(
-				         entry => {
-					         bool treeOpen = ImGui.TreeNodeEx(entry.Key.Value, ImGuiTreeNodeFlags.AllowItemOverlap);
-					         ImGui.SameLine();
-					         int killedCount = entry.Value.Count(
-						         x =>
-							         Plugin.Instance.MobHuntStruct->CurrentKills[x.CurrentKillsOffset] ==
-							         x.NeededKills);
-
-					         if (killedCount != entry.Value.Count) {
-						         ImGui.Text($"({killedCount}/{entry.Value.Count})");
-					         }
-					         else {
-						         ImGui.TextColored(
-							         new Vector4(0f, 1f, 0f, 1f),
-							         $"({killedCount}/{entry.Value.Count})");
-					         }
-
-					         return treeOpen;
-				         })) {
+		IEnumerable<KeyValuePair<string, Dictionary<KeyValuePair<uint, string>, List<MobHuntEntry>>>> expansionEntriesWithTreeNodes = Plugin.Instance
+			.MobHuntEntries
+			.Where(expansionEntry => ImGui.TreeNode(expansionEntry.Key));
+		foreach (KeyValuePair<string, Dictionary<KeyValuePair<uint, string>, List<MobHuntEntry>>> expansionEntry in expansionEntriesWithTreeNodes) {
+			IEnumerable<KeyValuePair<KeyValuePair<uint, string>, List<MobHuntEntry>>> mobEntriesWithTreeNodes = expansionEntry.Value
+				.Where(entry => {
+					bool treeOpen = ImGui.TreeNodeEx(entry.Key.Value, ImGuiTreeNodeFlags.AllowItemOverlap);
+					ImGui.SameLine();
+					int killedCount = entry.Value.Count(x => Plugin.Instance.MobHuntStruct->CurrentKills[x.CurrentKillsOffset] == x.NeededKills);
+					if (killedCount != entry.Value.Count) {
+						ImGui.Text($"({killedCount}/{entry.Value.Count})");
+					}
+					else {
+						ImGui.TextColored(
+							new Vector4(0f, 1f, 0f, 1f),
+							$"({killedCount}/{entry.Value.Count})");
+					}
+					return treeOpen;
+				});
+			foreach (KeyValuePair<KeyValuePair<uint, string>, List<MobHuntEntry>> entry in mobEntriesWithTreeNodes) {
 				foreach (MobHuntEntry? mobHuntEntry in entry.Value) {
 					if (Location.Database.ContainsKey(mobHuntEntry.MobHuntId)) {
 						if (InterfaceUtil.IconButton(FontAwesomeIcon.MapMarkerAlt, $"pin##{mobHuntEntry.MobHuntId}")) {
@@ -140,7 +136,7 @@ public class MainWindow: Window {
 						ImGui.SameLine();
 
 						if (Plugin.TeleportConsumer?.IsAvailable == true) {
-							if (InterfaceUtil.IconButton(FontAwesomeIcon.StreetView, $"t##{mobHuntEntry.MobHuntId}")) {
+							if (InterfaceUtil.IconButton(FontAwesomeIcon.StreetView, $"teleport##{mobHuntEntry.MobHuntId}")) {
 								Location.TeleportToNearestAetheryte(
 									mobHuntEntry.TerritoryType,
 									mobHuntEntry.MapId,
@@ -150,6 +146,20 @@ public class MainWindow: Window {
 							if (ImGui.IsItemHovered()) {
 								ImGui.BeginTooltip();
 								ImGui.Text("Teleport to nearest aetheryte");
+								ImGui.EndTooltip();
+							}
+
+							ImGui.SameLine();
+						}
+
+						if (Plugin.Instance.Configuration.EnableXivEspIntegration && Plugin.EspConsumer?.IsAvailable == true) {
+							if (InterfaceUtil.IconButton(FontAwesomeIcon.Search, $"esp##{mobHuntEntry.MobHuntId}")) {
+								Plugin.EspConsumer.SearchFor(mobHuntEntry.Name!);
+							}
+
+							if (ImGui.IsItemHovered()) {
+								ImGui.BeginTooltip();
+								ImGui.Text("Set XivEsp search to this target");
 								ImGui.EndTooltip();
 							}
 


### PR DESCRIPTION
There's now an option to send mob names to [XivEsp](https://github.com/PrincessRTFM/XivEsp) to have them easily highlighted on the screen for easier hunting. When integration is enabled in the settings, both the main hunt window and the local hunt window will have a new button to send mob names to XivEsp for highlighting. There is also a separate sub-option to make the `/phb next` command do the same for further simplicity. If XivEsp is not available, these configuration options will be disabled.

Note that there is a check to prevent overwriting advanced searches (XivEsp supports globs and regexen as well as substrings) but there is _no_ check to avoid overwriting a simple search that the user entered manually. This was deemed unfeasible; it would be possible to compare the existing search to known hunt targets, but once a stack of bills is completed, all unique targets from that stack are lost. It was also decided not to refuse overwriting _any_ search, as that would require the user to clear XivEsp's pattern between each hunt.