### PR TITLE
Add warnings about unsupported B-rank/ARR hunts

### DIFF
--- a/HuntBuddy/Configuration.cs
+++ b/HuntBuddy/Configuration.cs
@@ -19,6 +19,7 @@ public class Configuration: IPluginConfiguration {
 	public bool ShowLocalHuntIcons;
 	public bool HideLocalHuntBackground;
 	public bool HideCompletedHunts;
+	public bool SuppressEliteMarkLocationWarning;
 	public float IconScale = 1f;
 	public Vector4 IconBackgroundColour = new(0.76f, 0.75f, 0.76f, 0.8f);
 

--- a/HuntBuddy/Plugin.cs
+++ b/HuntBuddy/Plugin.cs
@@ -207,6 +207,10 @@ public class Plugin: IDalamudPlugin {
 						if (chosen != null) {
 							if (chosen.IsEliteMark) {
 								Service.Chat.Print($"Hunting elite mark {chosen.Name} in {chosen.TerritoryName}");
+								if (!this.Configuration.SuppressEliteMarkLocationWarning) {
+									Service.Chat.Print("Elite mark spawn locations are not available, since there are so many possibilities and the mob will only ever be in one place at a time."
+										+ "\n(You can suppress this warning in the plugin settings)");
+								}
 							}
 							else {
 								long remaining = chosen.NeededKills -

--- a/HuntBuddy/Utils/InterfaceUtil.cs
+++ b/HuntBuddy/Utils/InterfaceUtil.cs
@@ -67,4 +67,29 @@ public static class InterfaceUtil {
 	/// <param name="icon">Desired <see cref="FontAwesomeIcon"/> to be rendered.</param>
 	/// <returns>True if pressed.</returns>
 	public static bool IconButton(FontAwesomeIcon icon) => IconButton(icon, null);
+
+	/// <summary>
+	/// Draws horizontally-centered text in an ImGui window.
+	/// </summary>
+	/// <param name="text">The text to draw. Should be a single line.</param>
+	// I hate centering text in ImGui
+	public static void DrawCenteredText(string text) {
+		float width = ImGui.CalcTextSize(text).X;
+		float space = ImGui.GetContentRegionAvail().X;
+		ImGui.SetCursorPosX((space / 2) - (width / 2));
+		ImGui.Text(text);
+	}
+
+	/// <summary>
+	/// Draw a tooltip with simple text content, using the specified text wrapping position.
+	/// </summary>
+	/// <param name="maxWidth">The textwrap position for the tooltip text.</param>
+	/// <param name="text">The text of the tooltip.</param>
+	public static void DrawWrappedTooltip(float maxWidth, string text) {
+		ImGui.BeginTooltip();
+		ImGui.PushTextWrapPos(maxWidth);
+		ImGui.Text(text);
+		ImGui.PopTextWrapPos();
+		ImGui.EndTooltip();
+	}
 }

--- a/HuntBuddy/Windows/ConfigurationWindow.cs
+++ b/HuntBuddy/Windows/ConfigurationWindow.cs
@@ -1,6 +1,9 @@
 ﻿using System.Numerics;
 
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
+
+using HuntBuddy.Utils;
 
 using ImGuiNET;
 
@@ -10,7 +13,8 @@ namespace HuntBuddy.Windows;
 /// Configuration window.
 /// </summary>
 public class ConfigurationWindow: Window {
-	public ConfigurationWindow(): base(
+	public const int BaseTooltipWidth = 450;
+	public ConfigurationWindow() : base(
 		$"{Plugin.Instance.Name} configuration",
 		ImGuiWindowFlags.NoDocking,
 		true) {
@@ -20,9 +24,7 @@ public class ConfigurationWindow: Window {
 
 	public override void PreOpenCheck() {
 		if (Plugin.Instance.Configuration.LockWindowPositions) {
-			if (!this.Flags.HasFlag(ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove)) {
-				this.Flags |= ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove;
-			}
+			this.Flags |= ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove;
 		}
 		else {
 			this.Flags &= ~(ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove);
@@ -33,27 +35,65 @@ public class ConfigurationWindow: Window {
 		bool save = false;
 
 		ImGui.BeginDisabled(Plugin.EspConsumer?.IsAvailable == false);
+
 		save |= ImGui.Checkbox("Enable XivEsp plugin integration?", ref Plugin.Instance.Configuration.EnableXivEspIntegration);
+
 		ImGui.Indent();
 		save |= ImGui.Checkbox("Set XivEsp search when using '/phb next' command?", ref Plugin.Instance.Configuration.AutoSetEspSearchOnNextHuntCommand);
 		ImGui.Unindent();
+		if (ImGui.IsItemHovered()) {
+			InterfaceUtil.DrawWrappedTooltip(ImGuiHelpers.GlobalScale * BaseTooltipWidth,
+				"If enabled and XivEsp is available, the '/phb next' command will automatically set XivEsp's search"
+				+ "to the name of the chosen mark, EVEN IF you already have a custom search active.");
+		}
+
 		ImGui.EndDisabled();
 
 		ImGui.Spacing();
 
-		save |= ImGui.Checkbox("Lock plugin window positions", ref Plugin.Instance.Configuration.LockWindowPositions);
+		save |= ImGui.Checkbox("Lock plugin window positions and sizes",
+			ref Plugin.Instance.Configuration.LockWindowPositions);
+
 		save |= ImGui.Checkbox("Include hunt area on map by default",
 			ref Plugin.Instance.Configuration.IncludeAreaOnMap);
-		save |= ImGui.Checkbox("Show hunts in local area", ref Plugin.Instance.Configuration.ShowLocalHunts);
-		save |= ImGui.Checkbox(
-			"Show icons of hunts in local area",
+		if (ImGui.IsItemHovered()) {
+			InterfaceUtil.DrawWrappedTooltip(ImGuiHelpers.GlobalScale * BaseTooltipWidth,
+				$"{Plugin.Instance.Name} can show an approximate general area for hunt mobs around the flagged location."
+				+ "You can always hold SHIFT to toggle this when you click the button to flag a target on your map.");
+		}
+
+		save |= ImGui.Checkbox("Show hunts in local area",
+			   ref Plugin.Instance.Configuration.ShowLocalHunts);
+		if (ImGui.IsItemHovered()) {
+			InterfaceUtil.DrawWrappedTooltip(ImGuiHelpers.GlobalScale * BaseTooltipWidth,
+				$"If enabled, {Plugin.Instance.Name} will display an extra window with the hunt targets in your current map zone.");
+		}
+
+		save |= ImGui.Checkbox("Show icons of hunts in local area",
 			ref Plugin.Instance.Configuration.ShowLocalHuntIcons);
-		save |= ImGui.Checkbox(
-			"Hide background of local hunts window",
+		if (ImGui.IsItemHovered()) {
+			InterfaceUtil.DrawWrappedTooltip(ImGuiHelpers.GlobalScale * BaseTooltipWidth,
+				"These icons are taken from the hunt mark bills the game displays, and so may not be the clearest images available.");
+		}
+
+		save |= ImGui.Checkbox("Hide background of local hunts window",
 			ref Plugin.Instance.Configuration.HideLocalHuntBackground);
-		save |= ImGui.Checkbox(
-			"Hide completed targets in local hunts window",
+
+		save |= ImGui.Checkbox("Hide completed targets in local hunts window",
 			ref Plugin.Instance.Configuration.HideCompletedHunts);
+
+		save |= ImGui.Checkbox("Suppress chat warning about B-ranks not having locations",
+			ref Plugin.Instance.Configuration.SuppressEliteMarkLocationWarning);
+		if (ImGui.IsItemHovered()) {
+			InterfaceUtil.DrawWrappedTooltip(ImGuiHelpers.GlobalScale * BaseTooltipWidth,
+				$"When the '/phb next' command selects a B-rank mark, a warning is printed in your chat log that {Plugin.Instance.Name}"
+				+ " DOES NOT provide locations for B-rank hunt marks. If this warning annoys you, you can turn it off.\n"
+				+ "\n"
+				+ "Do not ask for B-rank locations to be provided.");
+		}
+
+		ImGui.Spacing();
+
 		save |= ImGui.SliderFloat("Hunt icon scale", ref Plugin.Instance.Configuration.IconScale, 0.2f, 2f, "%.2f");
 		if (ImGui.ColorEdit4("Hunt icon background colour", ref Plugin.Instance.Configuration.IconBackgroundColour)) {
 			Plugin.Instance.Configuration.IconBackgroundColourU32 =

--- a/HuntBuddy/Windows/MainWindow.cs
+++ b/HuntBuddy/Windows/MainWindow.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using System.Threading.Tasks;
 
 using Dalamud.Interface;
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
 
 using HuntBuddy.Utils;
@@ -26,9 +27,7 @@ public class MainWindow: Window {
 
 	public override void PreOpenCheck() {
 		if (Plugin.Instance.Configuration.LockWindowPositions) {
-			if (!this.Flags.HasFlag(ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove)) {
-				this.Flags |= ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove;
-			}
+			this.Flags |= ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove;
 		}
 		else {
 			this.Flags &= ~(ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove);
@@ -39,6 +38,22 @@ public class MainWindow: Window {
 		if (!Plugin.Instance.MobHuntEntriesReady) {
 			ImGui.Text("Reloading data ...");
 			return;
+		}
+
+		ImGui.BeginGroup();
+		ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.8f, 0.2f, 0.2f, 1));
+		InterfaceUtil.DrawCenteredText("B-RANK AND ARR HUNT MARK");
+		InterfaceUtil.DrawCenteredText("LOCATIONS ARE NOT SUPPORTED");
+		ImGui.PopStyleColor();
+		ImGui.EndGroup();
+		if (ImGui.IsItemHovered()) {
+			InterfaceUtil.DrawWrappedTooltip(ImGuiHelpers.GlobalScale * 400,
+				"B-rank marks have a varying number of potential spawn locations, and will only ever exist in one of them at a time."
+				+ $" {Plugin.Instance.Name} has no way to know which location a given mob is in, and as such cannot direct you to it."
+				+ " You can look up spawn maps online to find the possible spots for your target.\n"
+				+ "\n"
+				+ "Several ARR hunt marks are FATE mobs, which means they aren't always available."
+				+ $" Since {Plugin.Instance.Name} has no way to know if the FATE is up or not, ARR marks are not part of the plugin.");
 		}
 
 		if (InterfaceUtil.IconButton(FontAwesomeIcon.Redo, "Reload")) {


### PR DESCRIPTION
The `/phb next` command now prints a (suppressable) warning to your chat when an elite mark is chosen, informing you that such targets do not have locations in the plugin. The main window also warns of this, as well as the fact that hunts from A Realm Reborn are not supported.

Hopefully this will make users stop sending feedback asking for those two things to be added.