### PR TITLE
DRAFT: Add ARR hunt support

### DIFF
--- a/HuntBuddy/Location.cs
+++ b/HuntBuddy/Location.cs
@@ -23,441 +23,1777 @@ public static class Location {
 			init;
 		}
 
+		public int Radius { get; init; } = 50;
+
+		public uint Fate { get; init; }
+
 		public Vector2 Coordinate => new(this.X, this.Y);
 	}
 
 	// MobHuntId as key
-	public static readonly Dictionary<uint, PositionInfo> Database = new() {
-		// Heavensward
-		// Coerthas Western Highlands
-		{ 03481, new PositionInfo { X = 15.0f, Y = 12.0f } }, // Archaeornis
-		{ 03472, new PositionInfo { X = 32.0f, Y = 24.0f } }, // Bergthurs
-		{ 03471, new PositionInfo { X = 30.0f, Y = 31.0f } }, // Deepeye
-		{ 03476, new PositionInfo { X = 28.0f, Y = 12.0f } }, // Frost Grenade
-		{ 03480, new PositionInfo { X = 11.0f, Y = 17.0f } }, // Gelato
-		{ 03484, new PositionInfo { X = 10.0f, Y = 14.0f } }, // Ice Commander
-		{ 03475, new PositionInfo { X = 23.0f, Y = 16.0f } }, // Icetrap
-		{ 03487, new PositionInfo { X = 28.0f, Y = 09.0f } }, // Inland Tursus
-		{ 03483, new PositionInfo { X = 19.0f, Y = 29.0f } }, // Lone Yeti
-		{ 03485, new PositionInfo { X = 22.0f, Y = 21.0f } }, // Polar Bear
-		{ 03482, new PositionInfo { X = 16.0f, Y = 20.0f } }, // Rheum
-		{ 03473, new PositionInfo { X = 26.0f, Y = 24.0f } }, // Silver Wolf
-		{ 03490, new PositionInfo { X = 25.0f, Y = 32.0f } }, // Slate Yeti
-		{ 03478, new PositionInfo { X = 25.0f, Y = 12.0f } }, // Slush Zoblyn
-		{ 03470, new PositionInfo { X = 30.0f, Y = 32.0f } }, // Steinbock
-		{ 03474, new PositionInfo { X = 31.0f, Y = 20.0f } }, // Upland Mylodon
-		{ 03493, new PositionInfo { X = 09.0f, Y = 09.0f } }, // Vindthurs
-		{ 03479, new PositionInfo { X = 15.0f, Y = 17.0f } }, // Wooly Yak
+	public static readonly Dictionary<uint, List<PositionInfo>> Database = new()
+	{
+			// ARR
+			// B Rank
+			// Middle La Noscea
+			{ 02928 , new List<PositionInfo>() {						// Skogs Fru
+                new() { X = 24.0f, Y = 24.0f },
+				new() { X = 23.0f, Y = 23.0f },
+				new() { X = 25.0f, Y = 24.0f },
+				new() { X = 24.0f, Y = 21.0f },
+				new() { X = 24.0f, Y = 20.0f },
+				new() { X = 20.0f, Y = 22.0f },
+				new() { X = 20.0f, Y = 21.0f },
+				new() { X = 19.0f, Y = 20.0f },
+				new() { X = 21.0f, Y = 18.0f },
+				new() { X = 23.0f, Y = 17.0f },
+				new() { X = 21.0f, Y = 15.0f },
+				new() { X = 20.0f, Y = 14.0f },
+				new() { X = 19.0f, Y = 16.0f },
+				new() { X = 17.0f, Y = 17.0f },
+				new() { X = 18.0f, Y = 18.0f },
+				new() { X = 16.0f, Y = 15.0f },
+				new() { X = 17.0f, Y = 14.0f },
+				new() { X = 18.0f, Y = 13.0f },
+				new() { X = 14.0f, Y = 14.0f },
+				new() { X = 14.0f, Y = 12.0f },
+				new() { X = 17.0f, Y = 14.0f },
+				new() { X = 16.0f, Y = 11.0f },
+				new() { X = 18.0f, Y = 10.0f },
+				new() { X = 17.0f, Y = 8.0f  },
+			} },
+			// Lower La Noscea
+			{ 02929, new List<PositionInfo>() {							// Barbastelle
+				new() { X = 23.0f, Y = 36.0f },
+				new() { X = 22.0f, Y = 34.0f },
+				new() { X = 21.0f, Y = 36.0f },
+				new() { X = 20.0f, Y = 35.0f },
+				new() { X = 19.0f, Y = 35.0f },
+				new() { X = 17.0f, Y = 35.0f },
+				new() { X = 20.0f, Y = 37.0f },
+				new() { X = 23.0f, Y = 38.0f },
+				new() { X = 20.0f, Y = 32.0f },
+				new() { X = 25.0f, Y = 26.0f },
+				new() { X = 27.0f, Y = 26.0f },
+				new() { X = 26.0f, Y = 25.0f },
+				new() { X = 25.0f, Y = 22.0f },
+				new() { X = 29.0f, Y = 20.0f },
+				new() { X = 29.0f, Y = 18.0f },
+				new() { X = 29.0f, Y = 17.0f },
+				new() { X = 30.0f, Y = 14.0f },
+				new() { X = 31.0f, Y = 16.0f },
+				new() { X = 33.0f, Y = 16.0f },
+				new() { X = 34.0f, Y = 17.0f },
+			} },
+			// Western La Noscea
+			{ 02931, new List<PositionInfo>() {							// Dark Helmet
+                new() { X = 16.0f, Y = 34.0f },
+				new() { X = 17.0f, Y = 36.0f },
+				new() { X = 14.0f, Y = 35.0f },
+				new() { X = 33.0f, Y = 30.0f },
+				new() { X = 32.0f, Y = 29.0f },
+				new() { X = 31.0f, Y = 30.0f },
+				new() { X = 31.0f, Y = 28.0f },
+				new() { X = 35.0f, Y = 29.0f },
+				new() { X = 29.0f, Y = 25.0f },
+				new() { X = 28.0f, Y = 24.0f },
+				new() { X = 26.0f, Y = 24.0f },
+				new() { X = 25.0f, Y = 23.0f },
+				new() { X = 23.0f, Y = 25.0f },
+				new() { X = 23.0f, Y = 22.0f },
+				new() { X = 20.0f, Y = 22.0f },
+				new() { X = 19.0f, Y = 20.0f },
+				new() { X = 20.0f, Y = 19.0f },
+				new() { X = 17.0f, Y = 19.0f },
+				new() { X = 14.0f, Y = 17.0f },
+				new() { X = 16.0f, Y = 15.0f },
+				new() { X = 14.0f, Y = 16.0f },
+				new() { X = 14.0f, Y = 15.0f },
+				new() { X = 13.0f, Y = 15.0f },
+			} },
+			// Eastern La Noscea
+			{ 02930 , new List<PositionInfo>() {						// Bloody Mary
+                new() { X = 22.0f, Y = 25.0f },
+				new() { X = 20.0f, Y = 25.0f },
+				new() { X = 18.0f, Y = 25.0f },
+				new() { X = 18.0f, Y = 28.0f },
+				new() { X = 17.0f, Y = 30.0f },
+				new() { X = 15.0f, Y = 29.0f },
+				new() { X = 15.0f, Y = 30.0f },
+				new() { X = 21.0f, Y = 29.0f },
+				new() { X = 21.0f, Y = 30.0f },
+				new() { X = 17.0f, Y = 32.0f },
+				new() { X = 17.0f, Y = 33.0f },
+				new() { X = 20.0f, Y = 31.0f },
+				new() { X = 21.0f, Y = 33.0f },
+				new() { X = 21.0f, Y = 32.0f },
+				new() { X = 32.0f, Y = 27.0f },
+				new() { X = 28.0f, Y = 25.0f },
+				new() { X = 28.0f, Y = 27.0f },
+				new() { X = 28.0f, Y = 28.0f },
+				new() { X = 30.0f, Y = 25.0f },
+				new() { X = 31.0f, Y = 27.0f },
+				new() { X = 27.0f, Y = 31.0f },
+				new() { X = 26.0f, Y = 34.0f },
+				new() { X = 27.0f, Y = 33.0f },
+				new() { X = 29.0f, Y = 36.0f },
+				new() { X = 32.0f, Y = 36.0f },
+			} },
+			// Upper La Noscea
+			{ 02932 , new List<PositionInfo>() {						// Myradrosh
+                new() { X = 29.0f, Y = 21.0f },
+				new() { X = 28.0f, Y = 22.0f },
+				new() { X = 29.0f, Y = 22.0f },
+				new() { X = 28.0f, Y = 20.0f },
+				new() { X = 28.0f, Y = 24.0f },
+				new() { X = 30.0f, Y = 24.0f },
+				new() { X = 28.0f, Y = 26.0f },
+				new() { X = 31.0f, Y = 25.0f },
+				new() { X = 33.0f, Y = 26.0f },
+				new() { X = 34.0f, Y = 24.0f },
+				new() { X = 36.0f, Y = 24.0f },
+				new() { X = 14.0f, Y = 26.0f },
+				new() { X = 13.0f, Y = 25.0f },
+				new() { X = 13.0f, Y = 24.0f },
+				new() { X = 12.0f, Y = 23.0f },
+				new() { X = 12.0f, Y = 21.0f },
+				new() { X = 11.0f, Y = 22.0f },
+			} },
+			// Outer La Noscea
+			{ 02933, new List<PositionInfo>() {							// Vuokho
+                new() { X = 16.0f, Y = 18.0f },
+				new() { X = 15.0f, Y = 18.0f },
+				new() { X = 15.0f, Y = 17.0f },
+				new() { X = 13.0f, Y = 17.0f },
+				new() { X = 15.0f, Y = 15.0f },
+				new() { X = 14.0f, Y = 14.0f },
+				new() { X = 15.0f, Y = 12.0f },
+				new() { X = 15.0f, Y = 11.0f },
+				new() { X = 19.0f, Y = 15.0f },
+				new() { X = 23.0f, Y = 16.0f },
+				new() { X = 23.0f, Y = 15.0f },
+				new() { X = 21.0f, Y = 15.0f },
+				new() { X = 24.0f, Y = 16.0f },
+				new() { X = 23.0f, Y = 13.0f },
+				new() { X = 22.0f, Y = 11.0f },
+				new() { X = 22.0f, Y = 10.0f },
+				new() { X = 23.0f, Y = 9.0f  },
+				new() { X = 22.0f, Y = 8.0f  },
+				new() { X = 22.0f, Y = 7.0f  },
+				new() { X = 21.0f, Y = 7.0f  },
+				new() { X = 25.0f, Y = 8.0f  },
+				new() { X = 27.0f, Y = 6.0f  },
+				new() { X = 27.0f, Y = 7.0f  },
+			} },
+			// Central Thanalan
+			{ 02924, new List<PositionInfo>() {							// Ovjang
+				new() { X = 23.0f, Y = 35.0f },
+				new() { X = 24.0f, Y = 32.0f },
+				new() { X = 22.0f, Y = 31.0f },
+				new() { X = 26.0f, Y = 30.0f },
+				new() { X = 20.0f, Y = 26.0f },
+				new() { X = 19.0f, Y = 25.0f },
+				new() { X = 19.0f, Y = 24.0f },
+				new() { X = 17.0f, Y = 23.0f },
+				new() { X = 19.0f, Y = 21.0f },
+				new() { X = 16.0f, Y = 19.0f },
+				new() { X = 18.0f, Y = 19.0f },
+				new() { X = 22.0f, Y = 21.0f },
+				new() { X = 18.0f, Y = 18.0f },
+				new() { X = 16.0f, Y = 16.0f },
+				new() { X = 16.0f, Y = 13.0f },
+				new() { X = 18.0f, Y = 13.0f },
+				new() { X = 22.0f, Y = 14.0f },
+				new() { X = 22.0f, Y = 16.0f },
+				new() { X = 21.0f, Y = 16.0f },
+				new() { X = 26.0f, Y = 18.0f },
+				new() { X = 28.0f, Y = 18.0f },
+				new() { X = 27.0f, Y = 22.0f },
+				new() { X = 30.0f, Y = 21.0f },
+			} },
+			// Western Thanalan
+			{ 02923, new List<PositionInfo>() {							// Sewer Syrup
+				new() { X = 26.0f, Y = 26.0f },
+				new() { X = 21.0f, Y = 28.0f },
+				new() { X = 20.0f, Y = 29.0f },
+				new() { X = 19.0f, Y = 29.0f },
+				new() { X = 21.0f, Y = 25.0f },
+				new() { X = 21.0f, Y = 24.0f },
+				new() { X = 22.0f, Y = 24.0f },
+				new() { X = 23.0f, Y = 25.0f },
+				new() { X = 22.0f, Y = 22.0f },
+				new() { X = 23.0f, Y = 20.0f },
+				new() { X = 26.0f, Y = 19.0f },
+				new() { X = 27.0f, Y = 17.0f },
+				new() { X = 18.0f, Y = 17.0f },
+				new() { X = 17.0f, Y = 16.0f },
+				new() { X = 18.0f, Y = 15.0f },
+				new() { X = 14.0f, Y = 8.0f  },
+				new() { X = 15.0f, Y = 6.0f  },
+				new() { X = 12.0f, Y = 7.0f  },
+				new() { X = 12.0f, Y = 6.0f  },
+				new() { X = 10.0f, Y = 7.0f  },
+				new() { X = 11.0f, Y = 5.0f  },
+				new() { X = 08.0f, Y = 5.0f  },
+			} },
+			// Eastern Thanalan
+			{ 02925, new List<PositionInfo>() {							// Gatling
+				new() { X = 13.0f, Y = 29.0f },
+				new() { X = 15.0f, Y = 26.0f },
+				new() { X = 16.0f, Y = 27.0f },
+				new() { X = 17.0f, Y = 26.0f },
+				new() { X = 17.0f, Y = 25.0f },
+				new() { X = 18.0f, Y = 25.0f },
+				new() { X = 20.0f, Y = 25.0f },
+				new() { X = 19.0f, Y = 23.0f },
+				new() { X = 18.0f, Y = 22.0f },
+				new() { X = 17.0f, Y = 20.0f },
+				new() { X = 16.0f, Y = 20.0f },
+				new() { X = 15.0f, Y = 19.0f },
+				new() { X = 15.0f, Y = 17.0f },
+				new() { X = 13.0f, Y = 16.0f },
+				new() { X = 11.0f, Y = 19.0f },
+				new() { X = 13.0f, Y = 19.0f },
+				new() { X = 18.0f, Y = 28.0f },
+				new() { X = 19.0f, Y = 29.0f },
+				new() { X = 21.0f, Y = 29.0f },
+				new() { X = 23.0f, Y = 27.0f },
+				new() { X = 25.0f, Y = 26.0f },
+				new() { X = 27.0f, Y = 25.0f },
+				new() { X = 28.0f, Y = 26.0f },
+				new() { X = 28.0f, Y = 27.0f },
+				new() { X = 28.0f, Y = 21.0f },
+				new() { X = 25.0f, Y = 24.0f },
+				new() { X = 23.0f, Y = 23.0f },
+				new() { X = 24.0f, Y = 21.0f },
+				new() { X = 23.0f, Y = 20.0f },
+				new() { X = 24.0f, Y = 19.0f },
+				new() { X = 23.0f, Y = 20.0f },
+				new() { X = 26.0f, Y = 17.0f },
+				new() { X = 27.0f, Y = 20.0f },
+				new() { X = 27.0f, Y = 18.0f },
+				new() { X = 29.0f, Y = 18.0f },
+			} },
+			// Southern Thanalan
+			{ 02926, new List<PositionInfo>() {							// Albin the Ashen
+				new() { X = 18.0f, Y = 30.0f },
+				new() { X = 17.0f, Y = 33.0f },
+				new() { X = 14.0f, Y = 34.0f },
+				new() { X = 15.0f, Y = 38.0f },
+				new() { X = 17.0f, Y = 36.0f },
+				new() { X = 19.0f, Y = 38.0f },
+				new() { X = 23.0f, Y = 38.0f },
+				new() { X = 25.0f, Y = 40.0f },
+				new() { X = 25.0f, Y = 36.0f },
+				new() { X = 23.0f, Y = 33.0f },
+				new() { X = 21.0f, Y = 34.0f },
+				new() { X = 21.0f, Y = 32.0f },
+				new() { X = 29.0f, Y = 35.0f },
+				new() { X = 24.0f, Y = 30.0f },
+				new() { X = 21.0f, Y = 29.0f },
+				new() { X = 20.0f, Y = 28.0f },
+				new() { X = 21.0f, Y = 26.0f },
+				new() { X = 19.0f, Y = 25.0f },
+				new() { X = 17.0f, Y = 26.0f },
+				new() { X = 16.0f, Y = 24.0f },
+				new() { X = 17.0f, Y = 23.0f },
+				new() { X = 18.0f, Y = 23.0f },
+				new() { X = 18.0f, Y = 21.0f },
+				new() { X = 21.0f, Y = 23.0f },
+				new() { X = 24.0f, Y = 25.0f },
+				new() { X = 21.0f, Y = 21.0f },
+				new() { X = 19.0f, Y = 19.0f },
+				new() { X = 16.0f, Y = 20.0f },
+				new() { X = 24.0f, Y = 21.0f },
+				new() { X = 28.0f, Y = 21.0f },
+				new() { X = 31.0f, Y = 18.0f },
+				new() { X = 33.0f, Y = 20.0f },
+				new() { X = 19.0f, Y = 17.0f },
+				new() { X = 17.0f, Y = 17.0f },
+				new() { X = 17.0f, Y = 12.0f },
+				new() { X = 18.0f, Y = 11.0f },
+				new() { X = 18.0f, Y = 10.0f },
+				new() { X = 21.0f, Y = 11.0f },
+				new() { X = 24.0f, Y = 12.0f },
+				new() { X = 25.0f, Y = 11.0f },
+				new() { X = 25.0f, Y = 9.0f  },
+				new() { X = 23.0f, Y = 8.0f  },
+			} },
+			// Northern Thanalan
+			{ 02927, new List<PositionInfo>() {							// Flame Sergeant Dalvag
+				new() { X = 21.0f, Y = 28.0f },
+				new() { X = 22.0f, Y = 27.0f },
+				new() { X = 23.0f, Y = 26.0f },
+				new() { X = 24.0f, Y = 25.0f },
+				new() { X = 22.0f, Y = 25.0f },
+				new() { X = 24.0f, Y = 24.0f },
+				new() { X = 24.0f, Y = 23.0f },
+				new() { X = 23.0f, Y = 23.0f },
+				new() { X = 16.0f, Y = 19.0f },
+				new() { X = 15.0f, Y = 19.0f },
+				new() { X = 19.0f, Y = 18.0f },
+				new() { X = 18.0f, Y = 17.0f },
+				new() { X = 18.0f, Y = 17.0f },
+				new() { X = 19.0f, Y = 17.0f },
+				new() { X = 17.0f, Y = 17.0f },
+				new() { X = 17.0f, Y = 15.0f },
+				new() { X = 16.0f, Y = 16.0f },
+				new() { X = 16.0f, Y = 14.0f },
+			} },
+			// Central Shroud
+			{ 02919, new List<PositionInfo>() {							// White Joker
+				new() { X = 22.0f, Y = 30.0f },
+				new() { X = 23.0f, Y = 27.0f },
+				new() { X = 22.0f, Y = 24.0f },
+				new() { X = 27.0f, Y = 23.0f },
+				new() { X = 28.0f, Y = 22.0f },
+				new() { X = 30.0f, Y = 23.0f },
+				new() { X = 27.0f, Y = 21.0f },
+				new() { X = 29.0f, Y = 20.0f },
+				new() { X = 31.0f, Y = 19.0f },
+				new() { X = 29.0f, Y = 14.0f },
+				new() { X = 21.0f, Y = 16.0f },
+				new() { X = 19.0f, Y = 18.0f },
+				new() { X = 17.0f, Y = 18.0f },
+				new() { X = 16.0f, Y = 20.0f },
+				new() { X = 16.0f, Y = 21.0f },
+				new() { X = 16.0f, Y = 24.0f },
+				new() { X = 14.0f, Y = 20.0f },
+				new() { X = 13.0f, Y = 21.0f },
+				new() { X = 12.0f, Y = 19.0f },
+				new() { X = 10.0f, Y = 19.0f },
+				new() { X = 10.0f, Y = 17.0f },
+				new() { X = 10.0f, Y = 22.0f },
+				new() { X = 12.0f, Y = 23.0f },
+			} },
+			// South Shroud
+			{ 02921, new List<PositionInfo>() {							// Monarch Ogrefly
+				new() { X = 17.0f, Y = 32.0f },
+				new() { X = 16.0f, Y = 32.0f },
+				new() { X = 18.0f, Y = 31.0f },
+				new() { X = 17.0f, Y = 31.0f },
+				new() { X = 16.0f, Y = 28.0f },
+				new() { X = 16.0f, Y = 27.0f },
+				new() { X = 19.0f, Y = 28.0f },
+				new() { X = 19.0f, Y = 27.0f },
+				new() { X = 21.0f, Y = 28.0f },
+				new() { X = 22.0f, Y = 26.0f },
+				new() { X = 23.0f, Y = 24.0f },
+				new() { X = 27.0f, Y = 22.0f },
+				new() { X = 29.0f, Y = 24.0f },
+				new() { X = 31.0f, Y = 25.0f },
+				new() { X = 32.0f, Y = 24.0f },
+				new() { X = 33.0f, Y = 24.0f },
+				new() { X = 22.0f, Y = 21.0f },
+				new() { X = 23.0f, Y = 22.0f },
+				new() { X = 22.0f, Y = 19.0f },
+				new() { X = 24.0f, Y = 18.0f },
+				new() { X = 27.0f, Y = 20.0f },
+				new() { X = 27.0f, Y = 18.0f },
+				new() { X = 27.0f, Y = 23.0f },
+				new() { X = 19.0f, Y = 18.0f },
+				new() { X = 17.0f, Y = 18.0f },
+				new() { X = 16.0f, Y = 19.0f },
+				new() { X = 17.0f, Y = 22.0f },
+				new() { X = 19.0f, Y = 22.0f },
+				new() { X = 17.0f, Y = 24.0f },
+			} },
+			// Eastern Shroud
+			{ 02920, new List<PositionInfo>() {							// Stinging Sophie
+				new() { X = 25.0f, Y = 17.0f },
+				new() { X = 24.0f, Y = 17.0f },
+				new() { X = 24.0f, Y = 15.0f },
+				new() { X = 26.0f, Y = 11.0f },
+				new() { X = 25.0f, Y = 10.0f },
+				new() { X = 25.0f, Y = 12.0f },
+				new() { X = 26.0f, Y = 13.0f },
+				new() { X = 27.0f, Y = 13.0f },
+				new() { X = 29.0f, Y = 11.0f },
+				new() { X = 28.0f, Y = 13.0f },
+				new() { X = 30.0f, Y = 13.0f },
+				new() { X = 32.0f, Y = 15.0f },
+				new() { X = 30.0f, Y = 18.0f },
+				new() { X = 27.0f, Y = 18.0f },
+				new() { X = 27.0f, Y = 19.0f },
+				new() { X = 32.0f, Y = 21.0f },
+				new() { X = 29.0f, Y = 21.0f },
+				new() { X = 26.0f, Y = 21.0f },
+				new() { X = 28.0f, Y = 23.0f },
+				new() { X = 27.0f, Y = 25.0f },
+				new() { X = 25.0f, Y = 24.0f },
+				new() { X = 26.0f, Y = 25.0f },
+				new() { X = 19.0f, Y = 25.0f },
+				new() { X = 23.0f, Y = 22.0f },
+				new() { X = 21.0f, Y = 22.0f },
+				new() { X = 17.0f, Y = 22.0f },
+				new() { X = 17.0f, Y = 23.0f },
+				new() { X = 16.0f, Y = 24.0f },
+				new() { X = 13.0f, Y = 24.0f },
+				new() { X = 14.0f, Y = 26.0f },
+				new() { X = 14.0f, Y = 27.0f },
+				new() { X = 20.0f, Y = 29.0f },
+				new() { X = 24.0f, Y = 31.0f },
+				new() { X = 22.0f, Y = 28.0f },
+				new() { X = 22.0f, Y = 29.0f },
+			} },
+			// North Shroud
+			{ 02922, new List<PositionInfo>() {							// Phecda
+				new() { X = 21.0f, Y = 30.0f },
+				new() { X = 19.0f, Y = 29.0f },
+				new() { X = 18.0f, Y = 29.0f },
+				new() { X = 16.0f, Y = 29.0f },
+				new() { X = 18.0f, Y = 27.0f },
+				new() { X = 17.0f, Y = 26.0f },
+				new() { X = 23.0f, Y = 28.0f },
+				new() { X = 25.0f, Y = 29.0f },
+				new() { X = 25.0f, Y = 26.0f },
+				new() { X = 26.0f, Y = 26.0f },
+				new() { X = 28.0f, Y = 27.0f },
+				new() { X = 28.0f, Y = 24.0f },
+				new() { X = 22.0f, Y = 24.0f },
+				new() { X = 26.0f, Y = 23.0f },
+				new() { X = 28.0f, Y = 22.0f },
+				new() { X = 29.0f, Y = 22.0f },
+				new() { X = 24.0f, Y = 20.0f },
+				new() { X = 23.0f, Y = 20.0f },
+				new() { X = 22.0f, Y = 21.0f },
+				new() { X = 19.0f, Y = 20.0f },
+			} },
+			// Coerthas Central Highlands
+			{ 02934, new List<PositionInfo>() {							// Naul
+				new() { X = 24.0f, Y = 20.0f },
+				new() { X = 24.0f, Y = 22.0f },
+				new() { X = 25.0f, Y = 24.0f },
+				new() { X = 26.0f, Y = 25.0f },
+				new() { X = 27.0f, Y = 21.0f },
+				new() { X = 28.0f, Y = 22.0f },
+				new() { X = 28.0f, Y = 26.0f },
+				new() { X = 29.0f, Y = 28.0f },
+				new() { X = 30.0f, Y = 30.0f },
+				new() { X = 31.0f, Y = 31.0f },
+				new() { X = 23.0f, Y = 27.0f },
+				new() { X = 21.0f, Y = 28.0f },
+				new() { X = 20.0f, Y = 29.0f },
+				new() { X = 18.0f, Y = 29.0f },
+				new() { X = 16.0f, Y = 29.0f },
+				new() { X = 16.0f, Y = 27.0f },
+				new() { X = 15.0f, Y = 26.0f },
+				new() { X = 13.0f, Y = 25.0f },
+				new() { X = 13.0f, Y = 28.0f },
+				new() { X = 11.0f, Y = 29.0f },
+				new() { X = 11.0f, Y = 27.0f },
+				new() { X = 09.0f, Y = 27.0f },
+				new() { X = 06.0f, Y = 29.0f },
+				new() { X = 22.0f, Y = 19.0f },
+				new() { X = 21.0f, Y = 16.0f },
+				new() { X = 20.0f, Y = 19.0f },
+				new() { X = 18.0f, Y = 19.0f },
+				new() { X = 17.0f, Y = 21.0f },
+				new() { X = 14.0f, Y = 20.0f },
+				new() { X = 16.0f, Y = 18.0f },
+				new() { X = 14.0f, Y = 18.0f },
+				new() { X = 11.0f, Y = 20.0f },
+				new() { X = 11.0f, Y = 19.0f },
+				new() { X = 09.0f, Y = 15.0f },
+				new() { X = 09.0f, Y = 14.0f },
+				new() { X = 09.0f, Y = 12.0f },
+				new() { X = 11.0f, Y = 13.0f },
+				new() { X = 12.0f, Y = 14.0f },
+				new() { X = 09.0f, Y = 21.0f },
+				new() { X = 06.0f, Y = 20.0f },
+				new() { X = 05.0f, Y = 18.0f },
+				new() { X = 04.0f, Y = 17.0f },
+				new() { X = 06.0f, Y = 16.0f },
+				new() { X = 33.0f, Y = 24.0f },
+				new() { X = 35.0f, Y = 23.0f },
+				new() { X = 36.0f, Y = 23.0f },
+				new() { X = 32.0f, Y = 17.0f },
+				new() { X = 35.0f, Y = 15.0f },
+				new() { X = 32.0f, Y = 15.0f },
+				new() { X = 28.0f, Y = 15.0f },
+				new() { X = 27.0f, Y = 13.0f },
+				new() { X = 25.0f, Y = 14.0f },
+				new() { X = 30.0f, Y = 12.0f },
+				new() { X = 28.0f, Y = 11.0f },
+				new() { X = 30.0f, Y = 11.0f },
+				new() { X = 25.0f, Y = 11.0f },
+				new() { X = 25.0f, Y = 9.0f  },
+				new() { X = 23.0f, Y = 8.0f  },
+				new() { X = 29.0f, Y = 8.0f  },
+				new() { X = 32.0f, Y = 7.0f  },
+			} },
+			// Mor Dhona
+			{ 02935, new List<PositionInfo>() {							// Leech King
+				new() { X = 19.0f, Y = 08.0f },
+				new() { X = 15.0f, Y = 10.0f },
+				new() { X = 14.0f, Y = 10.0f },
+				new() { X = 16.0f, Y = 12.0f },
+				new() { X = 14.0f, Y = 12.0f },
+				new() { X = 14.0f, Y = 14.0f },
+				new() { X = 12.0f, Y = 12.0f },
+				new() { X = 13.0f, Y = 14.0f },
+				new() { X = 09.0f, Y = 14.0f },
+				new() { X = 11.0f, Y = 15.0f },
+				new() { X = 12.0f, Y = 17.0f },
+				new() { X = 23.0f, Y = 11.0f },
+				new() { X = 24.0f, Y = 12.0f },
+				new() { X = 26.0f, Y = 13.0f },
+				new() { X = 25.0f, Y = 10.0f },
+				new() { X = 27.0f, Y = 10.0f },
+				new() { X = 27.0f, Y = 09.0f },
+				new() { X = 29.0f, Y = 08.0f },
+				new() { X = 28.0f, Y = 06.0f },
+				new() { X = 27.0f, Y = 13.0f },
+				new() { X = 30.0f, Y = 06.0f },
+				new() { X = 32.0f, Y = 07.0f },
+				new() { X = 33.0f, Y = 09.0f },
+				new() { X = 32.0f, Y = 10.0f },
+				new() { X = 32.0f, Y = 11.0f },
+				new() { X = 34.0f, Y = 12.0f },
+				new() { X = 32.0f, Y = 14.0f },
+				new() { X = 30.0f, Y = 15.0f },
+				new() { X = 29.0f, Y = 15.0f },
+				new() { X = 28.0f, Y = 14.0f },
+			} },
 
-		// The Sea of Clouds
-		{ 03524, new PositionInfo { X = 21.0f, Y = 06.0f } }, // Anzu
-		{ 03498, new PositionInfo { X = 28.0f, Y = 29.0f } }, // Cloudworm
-		{ 03496, new PositionInfo { X = 27.0f, Y = 30.0f } }, // Conodont
-		{ 03505, new PositionInfo { X = 19.0f, Y = 30.0f } }, // Dhalmel
-		{ 03511, new PositionInfo { X = 17.0f, Y = 10.0f } }, // Endymion
-		{ 03494, new PositionInfo { X = 11.0f, Y = 33.0f } }, // Gaelicat
-		{ 03495, new PositionInfo { X = 16.0f, Y = 36.0f } }, // Gastornis
-		{ 03512, new PositionInfo { X = 23.0f, Y = 09.0f } }, // Groundskeeper
-		{ 03506, new PositionInfo { X = 20.0f, Y = 30.0f } }, // Korrigan
-		{ 03501, new PositionInfo { X = 36.0f, Y = 24.0f } }, // Lan'laii Gundu
-		{ 03502, new PositionInfo { X = 36.0f, Y = 20.0f } }, // Nat'laii Gundu
-		{ 03516, new PositionInfo { X = 28.0f, Y = 10.0f } }, // Nat'laii Vundu
-		{ 03497, new PositionInfo { X = 29.0f, Y = 30.0f } }, // Obdella
-		{ 03499, new PositionInfo { X = 20.0f, Y = 34.0f } }, // Paissa
-		{ 03500, new PositionInfo { X = 36.0f, Y = 24.0f } }, // Sanuwa
-		{ 03514, new PositionInfo { X = 30.0f, Y = 14.0f } }, // Sanuwa Vundu
-		{ 03525, new PositionInfo { X = 21.0f, Y = 07.0f } }, // Toco Toco
-		{ 03523, new PositionInfo { X = 14.0f, Y = 07.0f } }, // Tsanahale
-		{ 03503, new PositionInfo { X = 35.0f, Y = 25.0f } }, // Vuk'laii Gundu
-		{ 03513, new PositionInfo { X = 18.0f, Y = 17.0f } }, // Vundu Totem
-		{ 03509, new PositionInfo { X = 09.0f, Y = 16.0f } }, // Window Wamoura
-		{ 03510, new PositionInfo { X = 10.0f, Y = 17.0f } }, // Window Wamouracampa
-		{ 03504, new PositionInfo { X = 20.0f, Y = 38.0f } }, // Wisent
+			// Daily Targets
+			// Middle La Noscea
+			{ 00849, new List<PositionInfo>() { new() { X = 18.0f, Y = 17.0f, Fate = 220 } } },		// Menuis
+			{ 00851, new List<PositionInfo>() { new() { X = 17.0f, Y =  9.0f, Fate = 238 } } },		// Chupacabra
+			// Lower La Noscea
+			{ 01357, new List<PositionInfo>() { new() { X = 20.0f, Y = 37.0f, Fate = 245 } } },		// Mandragora Prince
+			{ 00857, new List<PositionInfo>() { new() { X = 20.0f, Y = 33.0f, Fate = 333 } } },		// Padfoot
+			{ 00852, new List<PositionInfo>() { new() { X = 25.0f, Y = 25.0f, Fate = 257 } } },		// Cuachac
+			{ 00856, new List<PositionInfo>() { new() { X = 31.0f, Y = 13.0f, Fate = 265 } } },		// 426th Order Pickman Bu Ga
+			// Eastern La Noscea
+			{ 00858, new List<PositionInfo>() { new() { X = 26.0f, Y = 32.0f, Fate = 280   } } },	// Kokoroon Quickfingers
+			{ 01516, new List<PositionInfo>() { new() { X = 17.0f, Y = 31.0f, Fate = 563   } } },	// Jolly Green 
+			{ 01515, new List<PositionInfo>() { new() { X = 18.0f, Y = 28.0f, Fate = 561   } } },	// Sekhmet
+			{ 01517, new List<PositionInfo>() { new() { X = 18.0f, Y = 25.0f, Fate = 564   } } },	// Metshaldjas
+			{ 00411, new List<PositionInfo>() { new() { X = 23.0f, Y = 21.0f, Radius = 150 } } },	// Grass Raptor
+			{ 01822, new List<PositionInfo>() { new() { X = 25.0f, Y = 20.0f, Radius = 150 } } },	// 2nd Cohort Laquearius
+			{ 01823, new List<PositionInfo>() { new() { X = 27.0f, Y = 20.0f, Radius = 150 } } },	// 2nd Cohort Eques
+			{ 01825, new List<PositionInfo>() { new() { X = 28.0f, Y = 20.0f, Radius = 150 } } },	// 2nd Cohort Signifer
+			{ 01826, new List<PositionInfo>() { new() { X = 29.0f, Y = 20.0f, Radius = 150 } } },	// 2nd Cohort Vanguard
+			{ 00639, new List<PositionInfo>() { new() { X = 31.0f, Y = 25.0f, Radius = 150 } } },	// Colibri
+			{ 00361, new List<PositionInfo>() { new() { X = 31.0f, Y = 26.0f, Radius = 150 } } },	// Bloodshore Bell
+			{ 00373, new List<PositionInfo>() { new() { X = 27.0f, Y = 25.0f, Radius = 150 } } },	// Kobold Missionary
+			{ 00369, new List<PositionInfo>() { new() { X = 27.0f, Y = 25.0f, Radius = 150 } } },	// Kobold Pitman
+			{ 00351, new List<PositionInfo>() { new() { X = 26.0f, Y = 32.0f, Radius = 150 } } },	// Qiqirn Gullroaster
+			{ 00341, new List<PositionInfo>() { new() { X = 27.0f, Y = 35.0f, Radius = 150 } } },	// Apkallu
+			{ 00560, new List<PositionInfo>() { new() { X = 30.0f, Y = 35.0f, Radius = 150 } } },	// Snipper
+			{ 01313, new List<PositionInfo>() { new() { X = 30.0f, Y = 32.0f, Radius = 150 } } },	// Large Buffalo
+			{ 00353, new List<PositionInfo>() { new() { X = 18.0f, Y = 33.0f, Radius = 150 } } },	// Goobbue
+			{ 00352, new List<PositionInfo>() { new() { X = 17.0f, Y = 28.0f, Radius = 150 } } },	// Jungle Coeurl
+			{ 00026, new List<PositionInfo>() { new() { X = 19.0f, Y = 26.0f, Radius = 150 } } },	// Gigantoad
+			// Western La Noscea
+			{ 00862, new List<PositionInfo>() { new() { X = 26.0f, Y = 22.0f, Fate = 309   } } },	// Tryptix Stumblemox
+			{ 01518, new List<PositionInfo>() { new() { X = 18.0f, Y = 18.0f, Fate = 572   } } },	// Voll The Sharkskinned
+			{ 00343, new List<PositionInfo>() { new() { X = 13.0f, Y = 16.0f, Fate = 575   } } },	// Aermswys The Stained
+			{ 02356, new List<PositionInfo>() { new() { X = 11.0f, Y = 14.0f, Fate = 578   } } },	// Yarr The Wavefiend
+			{ 01529, new List<PositionInfo>() { new() { X = 14.0f, Y = 34.0f, Fate = 577   } } },	// Mantis King
+			{ 00861, new List<PositionInfo>() { new() { X = 36.0f, Y = 28.0f, Fate = 306   } } },	// Barometz
+			{ 00859, new List<PositionInfo>() { new() { X = 32.0f, Y = 28.0f, Fate = 290   } } },	// Gluttonous Gertrude
+			{ 00860, new List<PositionInfo>() { new() { X = 30.0f, Y = 29.0f, Fate = 295   } } },	// Old Six-Arms
+			{ 00565, new List<PositionInfo>() { new() { X = 20.0f, Y = 19.0f, Radius = 150 } } },	// Trenchtooth Sahagin
+			{ 00386, new List<PositionInfo>() { new() { X = 20.0f, Y = 18.0f, Radius = 150 } } },	// Shelfscale Sahagin
+			{ 00384, new List<PositionInfo>() { new() { X = 17.0f, Y = 19.0f, Radius = 150 } } },	// Shelfclaw Sahagin
+			{ 00389, new List<PositionInfo>() { new() { X = 19.0f, Y = 22.0f, Radius = 150 } } },	// Shelfspine Sahagin
+			{ 00360, new List<PositionInfo>() { new() { X = 13.0f, Y = 17.0f, Radius = 150 } } },	// Sea Wasp
+			{ 00559, new List<PositionInfo>() { new() { X = 12.0f, Y = 17.0f, Radius = 150 } } },	// Shelfeye Reaver
+			{ 01828, new List<PositionInfo>() { new() { X = 14.0f, Y = 13.0f, Radius = 150 } } },	// Sapsa Shelfclaw
+			{ 01830, new List<PositionInfo>() { new() { X = 14.0f, Y = 13.0f, Radius = 150 } } },	// Sapsa Shelftooth
+			{ 01829, new List<PositionInfo>() { new() { X = 15.0f, Y = 14.0f, Radius = 150 } } },	// Sapsa Shelfspine
+			{ 01852, new List<PositionInfo>() { new() { X = 14.0f, Y = 35.0f, Radius = 150 } } },	// Preying Mantis
+			{ 01853, new List<PositionInfo>() { new() { X = 12.0f, Y = 36.0f, Radius = 150 } } },	// Lammergeyer
+			// Upper La Noscea
+			{ 01519, new List<PositionInfo>() { new() { X = 34.0f, Y = 24.0f, Fate = 322   } } },	// Oannes
+			{ 01521, new List<PositionInfo>() { new() { X = 28.0f, Y = 24.0f, Fate = 329   } } },	// Zoredonite
+			{ 01522, new List<PositionInfo>() { new() { X = 28.0f, Y = 23.0f, Fate = 331   } } },	// Scarface Bugaal Ja
+			{ 01520, new List<PositionInfo>() { new() { X = 14.0f, Y = 24.0f, Fate = 323   } } },	// Karkinos
+			{ 00886, new List<PositionInfo>() { new() { X =  8.0f, Y = 21.0f, Fate = 314   } } },	// Simurgh
+			{ 00413, new List<PositionInfo>() { new() { X = 32.0f, Y = 24.0f, Radius = 150 } } },	// Mamool Ja Executioner
+			{ 00414, new List<PositionInfo>() { new() { X = 33.0f, Y = 25.0f, Radius = 150 } } },	// Mamool Ja Breeder
+			{ 00643, new List<PositionInfo>() { new() { X = 28.0f, Y = 22.0f, Radius = 150 } } },	// Uragnite
+			{ 00391, new List<PositionInfo>() { new() { X = 27.0f, Y = 22.0f, Radius = 150 } } },	// Salamander
+			{ 00376, new List<PositionInfo>() { new() { X = 26.0f, Y = 19.0f, Radius = 150 } } },	// Kobold Sidesman
+			// Outer La Noscea
+			{ 01524, new List<PositionInfo>() { new() { X = 22.0f, Y = 11.0f, Fate = 586   } } },	// 59th Order Pickman Be Ze
+			{ 02357, new List<PositionInfo>() { new() { X = 22.0f, Y =  8.0f, Fate = 599   } } },	// 5th Order Patriarch Ze Bu
+			{ 02516, new List<PositionInfo>() { new() { X = 22.0f, Y =  6.0f, Fate = 700   } } },	// 59th Order Roundsman Ge Ga
+			{ 01670, new List<PositionInfo>() { new() { X = 24.0f, Y =  6.0f, Fate = 597   } } },	// 59th Order Bedesman Bi Go
+			{ 01527, new List<PositionInfo>() { new() { X = 14.0f, Y = 15.0f, Fate = 594   } } },	// Number 128
+			{ 01523, new List<PositionInfo>() { new() { X = 16.0f, Y = 15.0f, Fate = 581   } } },	// Ose
+			{ 01526, new List<PositionInfo>() { new() { X = 15.0f, Y = 18.0f, Fate = 591   } } },	// Peryton
+			{ 01525, new List<PositionInfo>() { new() { X = 25.0f, Y = 18.0f, Fate = 589   } } },	// Brounger
+			{ 00412, new List<PositionInfo>() { new() { X = 20.0f, Y = 15.0f, Radius = 150 } } },	// Velociraptor
+			{ 00562, new List<PositionInfo>() { new() { X = 21.0f, Y = 15.0f, Radius = 150 } } },	// Kobold Quarryman
+			{ 00270, new List<PositionInfo>() { new() { X = 21.0f, Y = 14.0f, Radius = 150 } } },	// Grenade
+			{ 00377, new List<PositionInfo>() { new() { X = 22.0f, Y = 15.0f, Radius = 150 } } },	// Kobold Roundsman
+			{ 00375, new List<PositionInfo>() { new() { X = 22.0f, Y = 12.0f, Radius = 150 } } },	// Kobold Bedesman
+			{ 00371, new List<PositionInfo>() { new() { X = 23.0f, Y = 12.0f, Radius = 150 } } },	// Kobold Priest
+			{ 01832, new List<PositionInfo>() { new() { X = 22.0f, Y =  9.0f, Radius = 150 } } },	// U'Ghamaro Roundsman
+			{ 01834, new List<PositionInfo>() { new() { X = 22.0f, Y =  7.0f, Radius = 150 } } },	// U'Ghamaro Bedesman
+			{ 01835, new List<PositionInfo>() { new() { X = 22.0f, Y =  6.0f, Radius = 150 } } },	// U'Ghamaro Priest
+			{ 01833, new List<PositionInfo>() { new() { X = 23.0f, Y =  6.0f, Radius = 150 } } },	// U'Ghamaro Quarryman
+			{ 01836, new List<PositionInfo>() { new() { X = 21.0f, Y =  9.0f, Radius = 150 } } },	// Synthetic Doblyn
+			{ 00407, new List<PositionInfo>() { new() { X = 15.0f, Y = 12.5f, Radius = 150 } } },	// Ringtail
+			{ 00106, new List<PositionInfo>() { new() { X = 14.0f, Y = 11.0f, Radius = 150 } } },	// Coeurl
+			{ 00046, new List<PositionInfo>() { new() { X = 25.0f, Y = 18.0f, Radius = 150 } } },	// Plasmoid
 
-		// The Dravanian Forelands
-		{ 03565, new PositionInfo { X = 30.0f, Y = 16.0f } }, // Bandersnatch
-		{ 03566, new PositionInfo { X = 26.0f, Y = 11.0f } }, // Brown Bear
-		{ 03570, new PositionInfo { X = 28.0f, Y = 22.0f } }, // Clearwater Nanka
-		{ 03569, new PositionInfo { X = 27.0f, Y = 25.0f } }, // Clearwater Ninki Nanka
-		{ 03572, new PositionInfo { X = 28.0f, Y = 32.0f } }, // Dragonfly Watcher
-		{ 03567, new PositionInfo { X = 27.0f, Y = 22.0f } }, // Dravanian Aevis
-		{ 03576, new PositionInfo { X = 16.0f, Y = 33.0f } }, // Dravanian Wyvern
-		{ 03563, new PositionInfo { X = 36.0f, Y = 24.0f } }, // Feather Flea
-		{ 03578, new PositionInfo { X = 17.0f, Y = 26.0f } }, // Forelands Hippocerf
-		{ 03579, new PositionInfo { X = 18.0f, Y = 12.0f } }, // Gallimimus
-		{ 03571, new PositionInfo { X = 25.0f, Y = 29.0f } }, // Loaghtan
-		{ 03592, new PositionInfo { X = 27.0f, Y = 35.0f } }, // Loth Cultivator
-		{ 03590, new PositionInfo { X = 27.0f, Y = 35.0f } }, // Loth Firedrone
-		{ 03591, new PositionInfo { X = 29.0f, Y = 36.0f } }, // Loth Steeldrone
-		{ 03568, new PositionInfo { X = 28.0f, Y = 25.0f } }, // Melia
-		{ 03577, new PositionInfo { X = 18.0f, Y = 31.0f } }, // Miacid
-		{ 03555, new PositionInfo { X = 18.0f, Y = 12.0f } }, // Syricta
-		{ 03586, new PositionInfo { X = 31.0f, Y = 08.0f } }, // Thunder Dragon
-		{ 03582, new PositionInfo { X = 13.0f, Y = 15.0f } }, // Tyrannosaur
-		{ 03581, new PositionInfo { X = 13.0f, Y = 14.0f } }, // Vinegaroon
-		{ 03564, new PositionInfo { X = 35.0f, Y = 21.0f } }, // Wild Chocobo
+			// Central Shroud
+			{ 00445, new List<PositionInfo>() { new() { X = 23.0f, Y = 24.0f, Fate = 123   } } },	// Stagnant Water Sprite
+			{ 00512, new List<PositionInfo>() { new() { X = 25.0f, Y = 25.0f, Fate = 128   } } },	// Alux
+			{ 00447, new List<PositionInfo>() { new() { X = 20.0f, Y = 30.0f, Fate = 137   } } },	// Matagaigai
+			{ 00448, new List<PositionInfo>() { new() { X = 14.0f, Y = 25.0f, Fate = 142   } } },	// Lou Carcolh
+			{ 01329, new List<PositionInfo>() { new() { X = 13.0f, Y = 22.0f, Fate = 209   } } },	// Jaded Jody
+			{ 01661, new List<PositionInfo>() { new() { X = 11.0f, Y = 18.0f, Fate = 604   } } },	// Spiteful
+			{ 00446, new List<PositionInfo>() { new() { X = 17.0f, Y = 22.0f, Fate = 125   } } },	// Asipatra
+			{ 00051, new List<PositionInfo>() { new() { X = 31.0f, Y = 21.0f, Fate = 126   } } },	// Alpha Anole
+			{ 00238, new List<PositionInfo>() { new() { X = 13.0f, Y = 21.0f, Radius = 150 } } },	// Stroper
+			{ 00236, new List<PositionInfo>() { new() { X = 11.0f, Y = 19.0f, Radius = 150 } } },	// Revenant
+			{ 00131, new List<PositionInfo>() { new() { X =  9.0f, Y = 18.0f, Radius = 150 } } },	// Crater Golem
+			{ 00091, new List<PositionInfo>() { new() { X = 12.0f, Y = 16.0f, Radius = 150 } } },	// Spriggan
+			{ 00130, new List<PositionInfo>() { new() { X = 14.0f, Y = 18.0f, Radius = 150 } } },	// Lindwurm
+			{ 00055, new List<PositionInfo>() { new() { X = 17.0f, Y = 22.0f, Radius = 150 } } },	// Deathgaze
+			{ 00207, new List<PositionInfo>() { new() { X = 10.0f, Y = 23.0f, Radius = 150 } } },	// Floating Eye
+			// East Shroud
+			{ 00513, new List<PositionInfo>() { new() { X = 19.0f, Y = 27.0f, Fate = 144   } } },	// Prince Of Pestilence
+			{ 00449, new List<PositionInfo>() { new() { X = 21.0f, Y = 29.0f, Fate = 150   } } },	// Jackanapes
+			{ 02350, new List<PositionInfo>() { new() { X = 29.0f, Y = 21.0f, Fate = 691   } } },	// Proto Armor
+			{ 01665, new List<PositionInfo>() { new() { X = 29.0f, Y = 13.0f, Fate = 619   } } },	// Volxia Of The Blade
+			{ 01664, new List<PositionInfo>() { new() { X = 32.4f, Y = 14.4f, Fate = 616   } } },	// Daxio Of The Dawn
+			{ 00222, new List<PositionInfo>() { new() { X = 27.0f, Y = 24.0f, Radius = 150 } } },	// Molted Ziz
+			{ 00058, new List<PositionInfo>() { new() { X = 29.0f, Y = 20.0f, Radius = 150 } } },	// 3rd Cohort Laquearius
+			{ 00066, new List<PositionInfo>() { new() { X = 28.0f, Y = 20.0f, Radius = 150 } } },	// Sylvan Snarl
+			{ 00164, new List<PositionInfo>() { new() { X = 28.0f, Y = 17.0f, Radius = 150 } } },	// Dreamtoad
+			{ 00567, new List<PositionInfo>() { new() { X = 28.0f, Y = 17.0f, Radius = 150 } } },	// Sylphlands Condor
+			{ 00068, new List<PositionInfo>() { new() { X = 28.0f, Y = 16.0f, Radius = 150 } } },	// Sylpheed Sigh
+			{ 00069, new List<PositionInfo>() { new() { X = 28.0f, Y = 16.0f, Radius = 150 } } },	// Sylpheed Snarl
+			{ 00067, new List<PositionInfo>() { new() { X = 30.0f, Y = 11.0f, Radius = 150 } } },	// Sylpheed Screech
+			{ 00053, new List<PositionInfo>() {														// 3rd Cohort Hoplomachus
+				new() { X = 32.0f, Y = 20.0f },
+				new() { X = 29.1f, Y = 20.9f }
+			} },
+			{ 01662, new List<PositionInfo>() { new() { X = 23.0f, Y = 20.0f, Fate = 609   } } },	// Capricious Cassie
+			{ 02367, new List<PositionInfo>() { new() { X = 23.0f, Y = 18.0f, Fate = 692   } } },	// Kafre
+			{ 01666, new List<PositionInfo>() { new() { X = 20.0f, Y = 10.0f, Fate = 622   } } },	// Pulxio Of The Short Gale
+			{ 00061, new List<PositionInfo>() { new() { X = 32.0f, Y = 20.0f, Radius = 150 } } },	// 3rd Cohort Signifer
+			{ 00233, new List<PositionInfo>() { new() { X = 25.0f, Y = 20.0f, Radius = 150 } } },	// Old-Growth Treant
+			{ 00065, new List<PositionInfo>() { new() { X = 25.0f, Y = 21.0f, Radius = 150 } } },	// Sylvan Sigh
+			{ 00237, new List<PositionInfo>() { new() { X = 23.0f, Y = 20.0f, Radius = 150 } } },	// Morbol
+			{ 00064, new List<PositionInfo>() { new() { X = 23.0f, Y = 20.0f, Radius = 150 } } },	// Sylvan Screech
+			{ 00165, new List<PositionInfo>() { new() { X = 24.0f, Y = 16.0f, Radius = 150 } } },	// Milkroot Cluster
+			{ 00162, new List<PositionInfo>() { new() { X = 23.7f, Y = 14.4f, Radius = 150 } } },	// Milkroot Sapling
+			{ 00166, new List<PositionInfo>() { new() { X = 26.0f, Y = 13.0f, Radius = 150 } } },	// Sylph Bonnet
+			{ 00163, new List<PositionInfo>() { new() { X = 21.0f, Y = 10.0f, Radius = 150 } } },	// Sylphlands Sentinel
+			// South Shroud
+			{ 00514, new List<PositionInfo>() { new() { X = 20.0f, Y = 22.0f, Fate = 153   } } },	// Sirocco
+			{ 00451, new List<PositionInfo>() { new() { X = 14.0f, Y = 33.0f, Fate = 169   } } },	// Yabi Two-Tails
+			{ 01667, new List<PositionInfo>() { new() { X = 32.0f, Y = 25.0f, Fate = 628   } } },	// Phaia
+			{ 00170, new List<PositionInfo>() { new() { X = 25.0f, Y = 21.0f, Radius = 150 } } },	// Deepvoid Deathmouse
+			{ 00024, new List<PositionInfo>() { new() { X = 24.0f, Y = 22.0f, Radius = 150 } } },	// Treant
+			{ 00045, new List<PositionInfo>() { new() { X = 23.0f, Y = 24.0f, Radius = 150 } } },	// Will-O'-The-Wisp
+			{ 00566, new List<PositionInfo>() { new() { X = 18.0f, Y = 25.0f, Radius = 150 } } },	// Midland Condor
+			{ 00034, new List<PositionInfo>() { new() { X = 15.0f, Y = 29.0f, Radius = 150 } } },	// Adamantoise
+			{ 00235, new List<PositionInfo>() { new() { X = 17.0f, Y = 30.0f, Radius = 150 } } },	// Bigmouth Orobon
+			{ 00015, new List<PositionInfo>() { new() { X = 29.0f, Y = 25.0f, Radius = 150 } } },	// Wild Hog
+			{ 00008, new List<PositionInfo>() { new() { X = 31.0f, Y = 23.0f, Radius = 150 } } },	// Ked
+			{ 00112, new List<PositionInfo>() { new() { X = 32.0f, Y = 25.0f, Radius = 150 } } },	// Lesser Kalong
+			// North Shroud
+			{ 01669, new List<PositionInfo>() { new() { X = 23.0f, Y = 25.0f, Fate = 634   } } },	// Great Oak
+			{ 00516, new List<PositionInfo>() { new() { X = 25.0f, Y = 28.0f, Fate = 178   } } },	// Dschubba
+			{ 00452, new List<PositionInfo>() { new() { X = 26.0f, Y = 21.0f, Fate = 185   } } },	// Curupira
+			{ 01668, new List<PositionInfo>() { new() { X = 21.0f, Y = 19.0f, Fate = 632   } } },	// Daedalus
+			{ 00025, new List<PositionInfo>() { new() { X = 23.0f, Y = 25.0f, Radius = 150 } } },	// Dryad
+			{ 00029, new List<PositionInfo>() { new() { X = 21.0f, Y = 21.0f, Radius = 150 } } },	// Dullahan
+			{ 00174, new List<PositionInfo>() { new() { X = 20.0f, Y = 19.0f, Radius = 150 } } },	// Watchwolf
+			{ 00436, new List<PositionInfo>() { new() { X = 20.0f, Y = 18.0f, Radius = 150 } } },	// Ixali Windtalon
+			{ 00103, new List<PositionInfo>() { new() { X = 18.0f, Y = 19.0f, Radius = 150 } } },	// Ixali Boldwing
 
-		// The Churning Mists
-		{ 03619, new PositionInfo { X = 17.0f, Y = 27.0f } }, // Amphiptere
-		{ 03620, new PositionInfo { X = 24.0f, Y = 26.0f } }, // Archaeosaur
-		{ 03625, new PositionInfo { X = 18.0f, Y = 24.0f } }, // Bladed Vinegaroon
-		{ 03630, new PositionInfo { X = 25.0f, Y = 10.0f } }, // Blood Dragon
-		{ 03631, new PositionInfo { X = 09.0f, Y = 36.0f } }, // Cloud Aevis
-		{ 03629, new PositionInfo { X = 08.0f, Y = 19.0f } }, // Diresaur
-		{ 03623, new PositionInfo { X = 20.0f, Y = 12.0f } }, // Dragonet
-		{ 03626, new PositionInfo { X = 34.0f, Y = 21.0f } }, // Elder Syricta
-		{ 03628, new PositionInfo { X = 25.0f, Y = 30.0f } }, // Elder Wyvern
-		{ 03668, new PositionInfo { X = 10.0f, Y = 20.0f } }, // Gnarled Melia
-		{ 03614, new PositionInfo { X = 34.0f, Y = 28.0f } }, // Hropken
-		{ 03621, new PositionInfo { X = 09.0f, Y = 12.0f } }, // Limestone Golem
-		{ 03618, new PositionInfo { X = 20.0f, Y = 28.0f } }, // Lower Skylord
-		{ 03627, new PositionInfo { X = 33.0f, Y = 31.0f } }, // Mists Biast
-		{ 03622, new PositionInfo { X = 10.0f, Y = 18.0f } }, // Mists Drake
-		{ 03617, new PositionInfo { X = 23.0f, Y = 25.0f } }, // Moss Dragon
-		{ 03613, new PositionInfo { X = 28.0f, Y = 32.0f } }, // Sankchinni
-		{ 03615, new PositionInfo { X = 32.0f, Y = 15.0f } }, // Tulihand
-		{ 03624, new PositionInfo { X = 38.0f, Y = 17.7f } }, // Vouivre
-		{ 03616, new PositionInfo { X = 26.0f, Y = 20.0f } }, // Wadjet
+			// Western Thanalan
+			{ 00865, new List<PositionInfo>() { new() { X = 24.0f, Y = 21.0f, Fate = 347   } } },	// Doomed Gigantoad
+			{ 00866, new List<PositionInfo>() { new() { X = 22.0f, Y = 23.0f, Fate = 348   } } },	// Cactuar Jack
+			{ 00867, new List<PositionInfo>() { new() { X = 15.0f, Y = 16.0f, Fate = 353   } } },	// Bubbly Bernie
+			{ 00868, new List<PositionInfo>() { new() { X = 13.0f, Y = 10.0f, Fate = 357   } } },	// Crier Briareos
+			{ 00869, new List<PositionInfo>() { new() { X = 14.3f, Y =  6.7f, Fate = 366   } } },	// Daddy Longlegs
+			{ 01820, new List<PositionInfo>() { new() { X = 13.0f, Y =  6.0f, Radius = 150 } } },	// 4th Cohort Vanguard
+			{ 01815, new List<PositionInfo>() { new() { X = 12.0f, Y =  6.0f, Radius = 150 } } },	// 4th Cohort Hoplomachus
+			{ 01818, new List<PositionInfo>() { new() { X = 10.0f, Y =  5.0f, Radius = 150 } } },	// 4th Cohort Secutor
+			// Central Thanalan
+			{ 00871, new List<PositionInfo>() { new() { X = 19.0f, Y = 20.0f, Fate = 374 } } },		// Guguroon Wetnose
+			{ 00874, new List<PositionInfo>() { new() { X = 18.0f, Y = 23.0f, Fate = 389 } } },		// Spitfire
+			{ 00872, new List<PositionInfo>() { new() { X = 15.0f, Y = 19.0f, Fate = 376 } } },		// Babaroon Halfshell
+			{ 00875, new List<PositionInfo>() { new() { X = 17.0f, Y = 14.0f, Fate = 393 } } },		// Nest Commander
+			{ 00873, new List<PositionInfo>() { new() { X = 27.0f, Y = 19.0f, Fate = 385 } } },		// Vodyanoi
+			// Eastern Thanalan
+			{ 00877, new List<PositionInfo>() { new() { X = 14.0f, Y = 17.0f, Fate = 401   } } },	// Undertaker
+			{ 00878, new List<PositionInfo>() { new() { X = 26.0f, Y = 21.0f, Fate = 407   } } },	// Gossamer
+			{ 01503, new List<PositionInfo>() { new() { X = 27.0f, Y = 24.0f, Fate = 542   } } },	// Aeetes
+			{ 01504, new List<PositionInfo>() { new() { X = 30.0f, Y = 25.0f, Fate = 543   } } },	// Bagoly
+			{ 00271, new List<PositionInfo>() { new() { X = 26.0f, Y = 25.0f, Radius = 150 } } },	// Golden Fleece
+			{ 00634, new List<PositionInfo>() { new() { X = 26.0f, Y = 26.0f, Radius = 150 } } },	// Mirrorknight
+			{ 00275, new List<PositionInfo>() { new() { X = 30.0f, Y = 26.0f, Radius = 150 } } },	// Quartz Doblyn
+			// Southern Thanalan
+			{ 00885, new List<PositionInfo>() { new() { X = 14.0f, Y = 30.0f, Fate = 455   } } },	// Ulhuadshi
+			{ 00884, new List<PositionInfo>() { new() { X = 25.0f, Y = 34.0f, Fate = 436   } } },	// Blackbile Maladd Chah
+			{ 01506, new List<PositionInfo>() { new() { X = 24.0f, Y = 26.0f, Fate = 430   } } },	// Cindersoot Pegujj Chah
+			{ 01505, new List<PositionInfo>() { new() { X = 20.0f, Y = 20.0f, Fate = 423   } } },	// Aspidochelone
+			{ 01699, new List<PositionInfo>() { new() { X = 21.0f, Y = 19.0f, Fate = 546   } } },	// Bibireze Greysteel
+			{ 00257, new List<PositionInfo>() { new() { X = 17.0f, Y = 24.0f, Fate = 427   } } },	// Diamondjaw Nezedd Gah
+			{ 02354, new List<PositionInfo>() { new() { X = 26.0f, Y = 21.0f, Fate = 558   } } },	// Flamecrest Afajj Koh
+			{ 01507, new List<PositionInfo>() { new() { X = 32.0f, Y = 19.0f, Fate = 554   } } },	// Whitespark Hepugg Roh
+			{ 00882, new List<PositionInfo>() { new() { X = 23.0f, Y = 10.0f, Fate = 456   } } },	// Gisfrid The Grinder
+			{ 00290, new List<PositionInfo>() { new() { X = 14.0f, Y = 31.0f, Radius = 150 } } },	// Sandworm
+			{ 00285, new List<PositionInfo>() { new() { X = 12.0f, Y = 32.0f, Radius = 150 } } },	// Russet Yarzon
+			{ 00132, new List<PositionInfo>() { new() { X = 19.0f, Y = 35.0f, Radius = 150 } } },	// Smoke Bomb
+			{ 00324, new List<PositionInfo>() { new() { X = 19.0f, Y = 38.0f, Radius = 150 } } },	// Fallen Wizard
+			{ 00264, new List<PositionInfo>() { new() { X = 24.0f, Y = 36.0f, Radius = 150 } } },	// Sundrake
+			{ 02155, new List<PositionInfo>() { new() { X = 25.0f, Y = 35.0f, Radius = 150 } } },	// Amalj'aa Halberdier
+			{ 00260, new List<PositionInfo>() { new() { X = 25.0f, Y = 34.0f, Radius = 150 } } },	// Amalj'aa Divinator
+			{ 00252, new List<PositionInfo>() { new() { X = 26.0f, Y = 34.0f, Radius = 150 } } },	// Amalj'aa Sniper
+			{ 01838, new List<PositionInfo>() { new() { X = 23.0f, Y = 22.0f, Radius = 150 } } },	// Zahar'ak Archer
+			{ 00249, new List<PositionInfo>() { new() { X = 20.0f, Y = 23.0f, Radius = 150 } } },	// Amalj'aa Archer
+			{ 00339, new List<PositionInfo>() { new() { X = 18.0f, Y = 19.0f, Radius = 150 } } },	// Tempered Orator
+			{ 00245, new List<PositionInfo>() { new() { X = 18.0f, Y = 20.0f, Radius = 150 } } },	// Amalj'aa Lancer
+			{ 00243, new List<PositionInfo>() { new() { X = 16.0f, Y = 24.0f, Radius = 150 } } },	// Iron Tortoise
+			{ 00253, new List<PositionInfo>() { new() { X = 19.0f, Y = 26.0f, Radius = 150 } } },	// Amalj'aa Pugilist
+			{ 01840, new List<PositionInfo>() { new() { X = 29.0f, Y = 18.0f, Radius = 150 } } },	// Zahar'ak Thaumaturge
+			{ 01841, new List<PositionInfo>() { new() { X = 30.0f, Y = 19.0f, Radius = 150 } } },	// Zahar'ak Battle Drake
+			{ 01839, new List<PositionInfo>() { new() { X = 32.0f, Y = 20.0f, Radius = 150 } } },	// Zahar'ak Pugilist
+			// Northern Thanalan
+			{ 01511, new List<PositionInfo>() { new() { X = 25.0f, Y = 23.0f, Fate = 637   } } },	// Bomb Baron
+			{ 01508, new List<PositionInfo>() { new() { X = 25.0f, Y = 20.0f, Fate = 446   } } },	// Arimaspi
+			{ 01509, new List<PositionInfo>() { new() { X = 18.8f, Y = 14.3f, Fate = 450   } } },	// Vanguard Prototype
+			{ 00242, new List<PositionInfo>() { new() { X = 22.0f, Y = 23.0f, Radius = 150 } } },	// Ahriman
+			{ 00304, new List<PositionInfo>() { new() { X = 23.0f, Y = 23.0f, Radius = 150 } } },	// Basilisk
 
-		// The Dravanian Hinterlands
-		{ 03612, new PositionInfo { X = 25.0f, Y = 37.0f } }, // Bifericeras
-		{ 03609, new PositionInfo { X = 18.0f, Y = 36.0f } }, // Cockatrice
-		{ 03603, new PositionInfo { X = 12.0f, Y = 16.0f } }, // Crawler
-		{ 03594, new PositionInfo { X = 24.0f, Y = 21.0f } }, // Damselfly
-		{ 03598, new PositionInfo { X = 31.0f, Y = 22.0f } }, // Goblin Brandisher
-		{ 03601, new PositionInfo { X = 31.0f, Y = 22.0f } }, // Goblin Glider
-		{ 03600, new PositionInfo { X = 31.0f, Y = 22.0f } }, // Goblin Sharpshooter
-		{ 03599, new PositionInfo { X = 31.0f, Y = 22.0f } }, // Goblin Tinkerer
-		{ 03605, new PositionInfo { X = 10.0f, Y = 21.0f } }, // Great Morbol
-		{ 03597, new PositionInfo { X = 37.0f, Y = 24.0f } }, // Narbrooi
-		{ 03610, new PositionInfo { X = 17.0f, Y = 33.0f } }, // Okeanis
-		{ 03608, new PositionInfo { X = 12.0f, Y = 33.0f } }, // Opken
-		{ 03604, new PositionInfo { X = 11.0f, Y = 27.0f } }, // Orn Kite
-		{ 03607, new PositionInfo { X = 09.0f, Y = 34.0f } }, // Poroggo
-		{ 03595, new PositionInfo { X = 28.0f, Y = 27.0f } }, // Ratel
-		{ 03611, new PositionInfo { X = 12.0f, Y = 32.0f } }, // Sun Leech
-		{ 03593, new PositionInfo { X = 21.0f, Y = 16.0f } }, // Tarantula Hawk
-		{ 03596, new PositionInfo { X = 34.0f, Y = 19.0f } }, // Wildebeest
+			// Coerthas Central Highlands
+			{ 02355, new List<PositionInfo>() { new() { X = 34.0f, Y = 19.0f, Fate = 508   } } },	// Kozol Nomotl The Turbulent
+			{ 01439, new List<PositionInfo>() { new() { X = 33.0f, Y = 23.0f, Fate = 500   } } },	// Gozol Itzcan The Hatchet
+			{ 01427, new List<PositionInfo>() { new() { X = 27.0f, Y = 23.0f, Fate = 463   } } },	// Downy Dunstan
+			{ 01428, new List<PositionInfo>() { new() { X = 24.0f, Y = 23.0f, Fate = 464   } } },	// Gavial
+			{ 01434, new List<PositionInfo>() { new() { X = 21.0f, Y = 17.0f, Fate = 494   } } },	// Roc
+			{ 01430, new List<PositionInfo>() { new() { X = 15.0f, Y = 20.0f, Fate = 479   } } },	// Lutin
+			{ 01432, new List<PositionInfo>() { new() { X = 12.0f, Y = 23.0f, Fate = 484   } } },	// Rongeur
+			{ 01433, new List<PositionInfo>() { new() { X = 12.0f, Y = 25.0f, Fate = 490   } } },	// Klythios
+			{ 01530, new List<PositionInfo>() { new() { X =  5.0f, Y = 22.0f, Fate = 493   } } },	// Sebek
+			{ 01431, new List<PositionInfo>() { new() { X =  8.0f, Y = 12.0f, Fate = 480   } } },	// Seps
+			{ 01429, new List<PositionInfo>() { new() { X = 34.0f, Y = 13.0f, Fate = 475   } } },	// Gargamelle
+			{ 00659, new List<PositionInfo>() { new() { X = 28.0f, Y = 15.0f, Radius = 150 } } },	// Snow Wolf Pup
+			{ 00658, new List<PositionInfo>() { new() { X = 27.0f, Y = 14.0f, Radius = 150 } } },	// Vodoriga
+			{ 00794, new List<PositionInfo>() { new() { X = 29.0f, Y = 11.0f, Radius = 150 } } },	// Redhorn Ogre
+			{ 01182, new List<PositionInfo>() { new() { X = 32.0f, Y = 15.0f, Radius = 150 } } },	// Taurus
+			{ 01842, new List<PositionInfo>() { new() { X = 31.0f, Y = 17.0f, Radius = 150 } } },	// Natalan Windtalon
+			{ 01845, new List<PositionInfo>() { new() { X = 32.0f, Y = 18.0f, Radius = 150 } } },	// Natalan Fogcaller
+			{ 01844, new List<PositionInfo>() { new() { X = 34.0f, Y = 20.0f, Radius = 150 } } },	// Natalan Swiftbeak
+			{ 01846, new List<PositionInfo>() { new() { X = 34.0f, Y = 20.0f, Radius = 150 } } },	// Natalan Watchwolf
+			{ 01843, new List<PositionInfo>() { new() { X = 33.0f, Y = 24.0f, Radius = 150 } } },	// Natalan Boldwing
+			{ 00662, new List<PositionInfo>() { new() { X = 32.0f, Y = 27.0f, Radius = 150 } } },	// Ixali Boundwing
+			{ 00660, new List<PositionInfo>() { new() { X = 32.0f, Y = 27.0f, Radius = 150 } } },	// Ixali Wildtalon
+			{ 00784, new List<PositionInfo>() { new() { X = 25.0f, Y = 24.0f, Radius = 150 } } },	// Feral Croc
+			{ 00114, new List<PositionInfo>() { new() { X = 25.0f, Y = 20.0f, Radius = 150 } } },	// Ice Sprite
+			{ 01612, new List<PositionInfo>() { new() { X = 26.0f, Y = 19.0f, Radius = 150 } } },	// Highland Goobbue
+			{ 00795, new List<PositionInfo>() { new() { X = 24.0f, Y = 19.0f, Radius = 150 } } },	// Ornery Karakul
+			{ 01611, new List<PositionInfo>() { new() { X = 22.0f, Y = 17.0f, Radius = 150 } } },	// Snowstorm Goobbue
+			{ 00785, new List<PositionInfo>() { new() { X = 13.0f, Y = 25.0f, Radius = 150 } } },	// Giant Logger
+			{ 00786, new List<PositionInfo>() { new() { X = 12.0f, Y = 26.0f, Radius = 150 } } },	// Giant Lugger
+			{ 00787, new List<PositionInfo>() { new() { X = 15.0f, Y = 26.0f, Radius = 150 } } },	// Giant Reader
+			{ 00788, new List<PositionInfo>() { new() { X = 17.0f, Y = 29.0f, Radius = 150 } } },	// Biast
+			{ 00653, new List<PositionInfo>() { new() { X = 15.0f, Y = 31.0f, Radius = 150 } } },	// Snow Wolf
+			{ 00790, new List<PositionInfo>() { new() { X =  8.0f, Y = 20.0f, Radius = 150 } } },	// Hippocerf
+			{ 01850, new List<PositionInfo>() { new() { X =  4.0f, Y = 22.0f, Radius = 150 } } },	// Baritine Croc
+			{ 00637, new List<PositionInfo>() { new() { X =  9.0f, Y = 12.0f, Radius = 150 } } },	// Dragonfly
+			{ 01849, new List<PositionInfo>() { new() { X = 24.0f, Y =  8.0f, Radius = 150 } } },	// Downy Aevis
 
-		// Azys Lla
-		{ 03545, new PositionInfo { X = 35.0f, Y = 24.0f } }, // 6th Legion Vanguard
-		{ 03552, new PositionInfo { X = 27.0f, Y = 33.0f } }, // Adamantite Claw
-		{ 03540, new PositionInfo { X = 31.0f, Y = 06.0f } }, // Allagan Chimera
-		{ 03534, new PositionInfo { X = 15.0f, Y = 13.0f } }, // Clockwork Engineer
-		{ 03536, new PositionInfo { X = 13.0f, Y = 08.0f } }, // Clockwork Harvestman
-		{ 03535, new PositionInfo { X = 18.0f, Y = 13.0f } }, // Clockwork Paladin
-		{ 03542, new PositionInfo { X = 35.0f, Y = 09.0f } }, // Corpse Flower
-		{ 03541, new PositionInfo { X = 29.5f, Y = 12.0f } }, // Empuse
-		{ 03537, new PositionInfo { X = 13.0f, Y = 17.0f } }, // Enforcement Droid
-		{ 03539, new PositionInfo { X = 27.0f, Y = 11.0f } }, // Lamia Cybrid
-		{ 03538, new PositionInfo { X = 28.0f, Y = 13.0f } }, // Lamia Thelytoke
-		{ 03580, new PositionInfo { X = 13.0f, Y = 33.0f } }, // Lesser Hydra
-		{ 03559, new PositionInfo { X = 18.0f, Y = 31.0f } }, // Meracydian Amphiptere
-		{ 03557, new PositionInfo { X = 08.0f, Y = 32.0f } }, // Meracydian Brobinyak
-		{ 03560, new PositionInfo { X = 08.0f, Y = 27.0f } }, // Meracydian Dragon
-		{ 03558, new PositionInfo { X = 06.0f, Y = 35.0f } }, // Meracydian Dragonet
-		{ 03554, new PositionInfo { X = 15.0f, Y = 29.0f } }, // Meracydian Falak
-		{ 03556, new PositionInfo { X = 14.0f, Y = 35.0f } }, // Meracydian Vouivre
-		{ 03533, new PositionInfo { X = 12.0f, Y = 15.0f } }, // Owlbear
-		{ 03543, new PositionInfo { X = 35.0f, Y = 08.0f } }, // Proto-naga
-		{ 03544, new PositionInfo { X = 33.0f, Y = 13.0f } }, // Reptoid
-		{ 03532, new PositionInfo { X = 09.0f, Y = 12.0f } }, // Snapper-rook
+			// Mor Dhona
+			{ 01444, new List<PositionInfo>() { new() { X = 27.0f, Y =  6.0f, Fate = 527   } } },	// Gwyllgi
+			{ 01442, new List<PositionInfo>() { new() { X = 31.0f, Y =  5.0f, Fate = 521   } } },	// Porus
+			{ 01443, new List<PositionInfo>() { new() { X = 29.8f, Y = 14.4f, Fate = 525   } } },	// Dione
+			{ 01441, new List<PositionInfo>() { new() { X = 16.0f, Y = 14.0f, Fate = 516   } } },	// Nburu
+			{ 01610, new List<PositionInfo>() { new() { X = 13.0f, Y = 10.0f, Fate = 530   } } },	// Voluptuous Vivian
+			{ 00793, new List<PositionInfo>() { new() { X = 31.0f, Y =  5.0f, Radius = 150 } } },	// Hapalit
+			{ 01851, new List<PositionInfo>() { new() { X = 26.0f, Y = 13.0f, Radius = 150 } } },	// Lake Cobra
+			{ 00649, new List<PositionInfo>() { new() { X = 33.0f, Y = 16.0f, Radius = 150 } } },	// Gigas Bhikkhu
+			{ 00650, new List<PositionInfo>() { new() { X = 17.0f, Y = 15.0f, Radius = 150 } } },	// Daring Harrier
+			{ 00651, new List<PositionInfo>() { new() { X = 16.0f, Y = 17.0f, Radius = 150 } } },	// Raging Harrier
+			{ 01811, new List<PositionInfo>() { new() { X = 12.0f, Y = 16.0f, Radius = 150 } } },	// 5th Cohort Eques
+			{ 01809, new List<PositionInfo>() { new() { X = 12.0f, Y = 16.0f, Radius = 150 } } },	// 5th Cohort Hoplomachus
+			{ 01813, new List<PositionInfo>() { new() { X =  9.0f, Y = 14.0f, Radius = 150 } } },	// 5th Cohort Signifer
+			{ 00645, new List<PositionInfo>() { new() { X = 13.0f, Y = 10.0f, Radius = 150 } } },	// Mudpuppy
+			{ 00027, new List<PositionInfo>() { new() { X = 17.0f, Y =  9.0f, Radius = 150 } } },	// Nix
 
-		// Stormblood
-		// The Fringes
-		{ 05685, new PositionInfo { X = 10.0f, Y = 27.0f } }, // Diakka
-		{ 05674, new PositionInfo { X = 22.0f, Y = 16.0f } }, // Foper
-		{ 05697, new PositionInfo { X = 25.0f, Y = 27.0f } }, // Gazelle
-		{ 05676, new PositionInfo { X = 11.6f, Y = 12.0f } }, // Gazelle Hawk
-		{ 05679, new PositionInfo { X = 25.0f, Y = 15.0f } }, // Gelid Bhoot
-		{ 05686, new PositionInfo { X = 10.0f, Y = 27.0f } }, // Goosefish
-		{ 05671, new PositionInfo { X = 11.0f, Y = 11.0f } }, // Leshy
-		{ 05687, new PositionInfo { X = 11.0f, Y = 17.0f } }, // Mossling
-		{ 05683, new PositionInfo { X = 12.0f, Y = 17.0f } }, // Mountain Grizzly
-		{ 05691, new PositionInfo { X = 35.0f, Y = 25.0f } }, // Qalyana Brahmin
-		{ 05689, new PositionInfo { X = 35.0f, Y = 25.0f } }, // Qalyana Kshatriya
-		{ 05690, new PositionInfo { X = 35.0f, Y = 25.0f } }, // Qalyana Shudra
-		{ 05688, new PositionInfo { X = 35.0f, Y = 25.0f } }, // Sacred Marid
-		{ 05675, new PositionInfo { X = 10.0f, Y = 12.0f } }, // Sapria
-		{ 05677, new PositionInfo { X = 22.0f, Y = 11.0f } }, // Spinner
-		{ 05693, new PositionInfo { X = 29.0f, Y = 24.0f } }, // Teleoceras
-		{ 05678, new PositionInfo { X = 28.0f, Y = 15.0f } }, // Velodyna Pugil
-		{ 05680, new PositionInfo { X = 17.0f, Y = 10.0f } }, // Velodyna Sarcosuchus
 
-		// The Peaks
-		{ 05705, new PositionInfo { X = 25.0f, Y = 11.0f } }, // Crag Claw
-		{ 05701, new PositionInfo { X = 18.7f, Y = 12.9f } }, // Bloodglider
-		{ 05702, new PositionInfo { X = 14.0f, Y = 08.0f } }, // Fluturini
-		{ 05703, new PositionInfo { X = 12.0f, Y = 08.0f } }, // Gyr Abanian Hornbill
-		{ 05713, new PositionInfo { X = 25.0f, Y = 33.0f } }, // Highland Eruca
-		{ 05712, new PositionInfo { X = 24.0f, Y = 29.0f } }, // Jhammel
-		{ 05714, new PositionInfo { X = 15.0f, Y = 27.0f } }, // Kongamato
-		{ 05707, new PositionInfo { X = 34.0f, Y = 09.0f } }, // Marble Urolith
-		{ 05715, new PositionInfo { X = 09.0f, Y = 26.0f } }, // Pantera
-		{ 05708, new PositionInfo { X = 24.0f, Y = 14.0f } }, // Scarab Beetle
-		{ 05711, new PositionInfo { X = 24.0f, Y = 24.0f } }, // True Griffin
+			// Heavensward
+			// B Rank
+			// Coerthas Western Highlands
+			{ 04350, new List<PositionInfo>() {							// Alteci
+				new() { X = 19.0f, Y = 31.0f },
+				new() { X = 17.0f, Y = 29.0f },
+				new() { X = 17.0f, Y = 25.0f },
+				new() { X = 23.0f, Y = 28.0f },
+				new() { X = 22.0f, Y = 21.0f },
+				new() { X = 22.0f, Y = 18.0f },
+				new() { X = 18.0f, Y = 19.0f },
+				new() { X = 11.0f, Y = 17.0f },
+				new() { X =  7.0f, Y = 13.0f },
+				new() { X =  9.0f, Y = 14.0f },
+				new() { X = 15.0f, Y = 12.0f },
+				new() { X = 18.0f, Y = 13.0f },
+			} },
+			{ 04351, new List<PositionInfo>() {							// Kreutzet
+				new() { X = 25.0f, Y = 32.0f },
+				new() { X = 31.0f, Y = 27.0f },
+				new() { X = 28.0f, Y = 22.0f },
+				new() { X = 32.0f, Y = 18.0f },
+				new() { X = 34.0f, Y = 22.0f },
+				new() { X = 34.0f, Y = 21.0f },
+				new() { X = 28.0f, Y = 16.0f },
+				new() { X = 26.0f, Y = 12.0f },
+				new() { X = 29.0f, Y = 13.0f },
+				new() { X = 28.0f, Y =  8.0f },
+				new() { X = 36.0f, Y = 10.0f },
+				new() { X = 36.0f, Y = 13.0f },
+			} },
 
-		// The Ruby Sea
-		{ 05737, new PositionInfo { X = 31.0f, Y = 35.0f } }, // Bombfish
-		{ 05736, new PositionInfo { X = 34.0f, Y = 05.0f } }, // Coralshell
-		{ 05740, new PositionInfo { X = 26.0f, Y = 30.0f } }, // Flying Shark
-		{ 05742, new PositionInfo { X = 23.0f, Y = 33.0f } }, // Gasame
-		{ 05734, new PositionInfo { X = 14.0f, Y = 10.0f } }, // Gyuki
-		{ 05751, new PositionInfo { X = 25.0f, Y = 25.0f } }, // Naked Yumemi
-		{ 05743, new PositionInfo { X = 07.0f, Y = 30.0f } }, // Red Bukan
-		{ 05745, new PositionInfo { X = 08.0f, Y = 28.0f } }, // Red Honkan
-		{ 05744, new PositionInfo { X = 09.5f, Y = 25.2f } }, // Red Hyoe
-		{ 05738, new PositionInfo { X = 33.0f, Y = 11.0f } }, // Sea Serpent
-		{ 05739, new PositionInfo { X = 26.0f, Y = 06.0f } }, // Shiranui
-		{ 05746, new PositionInfo { X = 07.0f, Y = 27.0f } }, // Striped Ray
-		{ 05733, new PositionInfo { X = 29.0f, Y = 37.0f } }, // Tatsunoko
-		{ 05735, new PositionInfo { X = 35.0f, Y = 21.0f } }, // Unkiu
-		{ 05750, new PositionInfo { X = 25.0f, Y = 25.0f } }, // Yumemi
+			// The Sea of Clouds
+			{ 04352, new List<PositionInfo>() {							// Gnath Cometdrone
+				new() { X = 25.0f, Y = 32.0f },
+				new() { X = 28.0f, Y = 31.0f },
+				new() { X = 27.0f, Y = 37.0f },
+				new() { X = 18.0f, Y = 38.0f },
+				new() { X = 10.0f, Y = 35.0f },
+				new() { X = 17.0f, Y = 35.0f },
+				new() { X = 21.0f, Y = 34.0f },
+				new() { X = 12.0f, Y = 27.0f },
+				new() { X = 14.0f, Y = 31.0f },
+				new() { X = 20.0f, Y = 30.0f },
+			} },
+			{ 04353, new List<PositionInfo>() {							// Thextera
+				new() { X = 35.0f, Y = 28.0f },
+				new() { X = 39.0f, Y = 25.0f },
+				new() { X = 26.0f, Y = 25.0f },
+				new() { X = 29.0f, Y = 21.0f },
+				new() { X = 21.0f, Y = 20.0f },
+				new() { X = 32.0f, Y = 18.0f },
+				new() { X = 35.0f, Y = 14.0f },
+				new() { X = 34.0f, Y =  8.0f },
+				new() { X = 27.0f, Y =  7.0f },
+				new() { X = 34.0f, Y = 13.0f },
+			} },
 
-		// Yanxia
-		{ 05761, new PositionInfo { X = 18.0f, Y = 31.0f } }, // Bi Fang
-		{ 05769, new PositionInfo { X = 28.0f, Y = 08.0f } }, // Ebisu Catfish
-		{ 05752, new PositionInfo { X = 27.0f, Y = 34.0f } }, // Lupin Bladehand
-		{ 05754, new PositionInfo { X = 24.0f, Y = 32.0f } }, // Lupin Bowhand
-		{ 05753, new PositionInfo { X = 23.0f, Y = 28.0f } }, // Lupin Spearhand
-		{ 05768, new PositionInfo { X = 19.0f, Y = 11.0f } }, // Magatsu Kiyofusa
-		{ 05763, new PositionInfo { X = 33.0f, Y = 17.0f } }, // Minobi
-		{ 05757, new PositionInfo { X = 30.0f, Y = 23.0f } }, // Rhino Beetle
-		{ 05765, new PositionInfo { X = 30.0f, Y = 34.0f } }, // Taoquan
-		{ 05755, new PositionInfo { X = 24.0f, Y = 32.0f } }, // Tenaga
-		{ 05764, new PositionInfo { X = 23.0f, Y = 30.0f } }, // Vanara
-		{ 05762, new PositionInfo { X = 25.0f, Y = 26.0f } }, // Water Serpent
+			// The Dravanian Forelands
+			{ 04356, new List<PositionInfo>() {							// Scitalis
+				new() { X = 32.0f, Y = 33.0f },
+				new() { X = 36.0f, Y = 29.0f },
+				new() { X = 37.0f, Y = 26.0f },
+				new() { X = 34.0f, Y = 20.0f },
+				new() { X = 23.0f, Y = 31.0f },
+				new() { X = 27.0f, Y = 27.0f },
+				new() { X = 25.0f, Y = 20.0f },
+				new() { X = 28.0f, Y = 20.0f },
+				new() { X = 26.0f, Y =  8.0f },
+				new() { X = 29.0f, Y = 11.0f },
+			} },
+			{ 04357, new List<PositionInfo>() {							// The Scarecrow
+				new() { X =  7.0f, Y = 35.0f },
+				new() { X = 10.0f, Y = 38.0f },
+				new() { X = 17.0f, Y = 27.0f },
+				new() { X = 16.0f, Y = 30.0f },
+				new() { X = 14.0f, Y = 23.0f },
+				new() { X = 17.0f, Y = 24.0f },
+				new() { X = 12.0f, Y = 20.0f },
+				new() { X =  7.0f, Y = 20.0f },
+				new() { X =  8.0f, Y = 15.0f },
+				new() { X =  8.0f, Y = 11.0f },
+				new() { X = 10.0f, Y =  9.0f },
+				new() { X = 15.0f, Y = 14.0f },
+			} },
 
-		// The Azim Steppe
-		{ 05785, new PositionInfo { X = 15.0f, Y = 19.0f } }, // Baras
-		{ 05788, new PositionInfo { X = 17.0f, Y = 26.0f } }, // Chaochu
-		{ 05777, new PositionInfo { X = 23.0f, Y = 15.0f } }, // Halgai
-		{ 05778, new PositionInfo { X = 16.0f, Y = 11.0f } }, // Khun Chuluu
-		{ 05781, new PositionInfo { X = 31.0f, Y = 17.0f } }, // Mammoth
-		{ 05783, new PositionInfo { X = 12.0f, Y = 29.0f } }, // Manzasiri
-		{ 05775, new PositionInfo { X = 28.0f, Y = 13.0f } }, // Matamata
-		{ 05782, new PositionInfo { X = 09.0f, Y = 21.0f } }, // Matanga
-		{ 05779, new PositionInfo { X = 23.0f, Y = 10.0f } }, // Muu Shuwuu
-		{ 05780, new PositionInfo { X = 34.0f, Y = 18.0f } }, // Purbol
-		{ 05776, new PositionInfo { X = 26.0f, Y = 29.0f } }, // Steppe Dhole
-		{ 05773, new PositionInfo { X = 31.0f, Y = 32.0f } }, // Steppe Dzo
+			// The Churning Mists
+			{ 04358, new List<PositionInfo>() {							// Squonk
+				new() { X = 15.0f, Y = 24.0f },
+				new() { X = 21.0f, Y = 21.0f },
+				new() { X = 25.0f, Y = 25.0f },
+				new() { X = 32.0f, Y = 19.0f },
+				new() { X = 36.0f, Y = 39.0f },
+				new() { X = 34.0f, Y = 31.0f },
+				new() { X = 37.0f, Y = 21.0f },
+				new() { X = 14.0f, Y = 29.0f },
+				new() { X = 18.0f, Y = 30.0f },
+				new() { X = 18.0f, Y = 32.0f },
+				new() { X = 32.0f, Y = 36.0f },
+				new() { X = 27.0f, Y = 34.0f },
+				new() { X = 27.0f, Y = 29.0f },
+			} },
+			{ 04359, new List<PositionInfo>() {							// Sanu Vali of Dancing Wings
+				new() { X =  7.0f, Y = 20.0f },
+				new() { X =  9.0f, Y = 16.0f },
+				new() { X =  7.0f, Y =  8.0f },
+				new() { X = 15.0f, Y =  8.0f },
+				new() { X = 19.0f, Y = 10.0f },
+				new() { X = 23.0f, Y = 11.0f },
+				new() { X = 25.0f, Y = 13.0f },
+				new() { X = 16.0f, Y = 14.0f },
+				new() { X = 22.0f, Y = 16.0f },
+				new() { X = 21.0f, Y =  7.0f },
+				new() { X = 29.0f, Y =  7.0f },
+				new() { X = 36.0f, Y =  9.0f },
+				new() { X = 37.0f, Y = 15.0f },
+			} },
 
-		// The Lochs
-		{ 05723, new PositionInfo { X = 18.0f, Y = 32.0f } }, // Abaddon
-		{ 05725, new PositionInfo { X = 26.0f, Y = 11.0f } }, // Abalathian Minotaur
-		{ 05720, new PositionInfo { X = 25.0f, Y = 18.0f } }, // Chelone
-		{ 05727, new PositionInfo { X = 29.0f, Y = 15.0f } }, // Creeping Edila
-		{ 05729, new PositionInfo { X = 05.7f, Y = 26.7f } }, // Dark Clay Beast
-		{ 05732, new PositionInfo { X = 23.0f, Y = 10.0f } }, // Guard Bhoot
-		{ 05716, new PositionInfo { X = 08.0f, Y = 17.0f } }, // Kaluk
-		{ 05724, new PositionInfo { X = 16.0f, Y = 12.0f } }, // Loch Leech
-		{ 05730, new PositionInfo { X = 17.0f, Y = 16.0f } }, // Loch Nanka
-		{ 05717, new PositionInfo { X = 20.0f, Y = 18.0f } }, // Phoebad
-		{ 05721, new PositionInfo { X = 16.0f, Y = 21.0f } }, // Soblyn
-		{ 05722, new PositionInfo { X = 22.0f, Y = 23.0f } }, // Salt Dhruva
-		{ 05728, new PositionInfo { X = 17.0f, Y = 08.0f } }, // Specter
-		{ 05726, new PositionInfo { X = 25.0f, Y = 29.0f } }, // Vepar
-		{ 05719, new PositionInfo { X = 20.0f, Y = 25.0f } }, // Yabby
-		// Shadowbringers
-		// Lakeland
-		{ 08498, new PositionInfo { X = 19.0f, Y = 09.0f } }, // Chiliad Cama
-		{ 08502, new PositionInfo { X = 28.0f, Y = 23.2f } }, // Violet Triffid
-		{ 08503, new PositionInfo { X = 14.0f, Y = 16.5f } }, // Gnole
-		{ 08504, new PositionInfo { X = 24.4f, Y = 23.9f } }, // Wetland Warg
-		{ 08505, new PositionInfo { X = 33.2f, Y = 10.0f } }, // White Gremlin
-		{ 08507, new PositionInfo { X = 25.8f, Y = 23.3f } }, // Hoptrap
-		{ 08508, new PositionInfo { X = 28.5f, Y = 36.7f } }, // Wolverine
-		{ 08511, new PositionInfo { X = 11.3f, Y = 11.0f } }, // Smilodon
-		{ 08514, new PositionInfo { X = 34.2f, Y = 17.0f } }, // Ya-te-veo
-		{ 08515, new PositionInfo { X = 29.0f, Y = 17.6f } }, // Proterosuchus
-		{ 08786, new PositionInfo { X = 20.5f, Y = 25.3f } }, // Lake Viper
+			// The Dravanian Hinterlands
+			{ 04354, new List<PositionInfo>() {							// Pterygotus
+				new() { X = 13.0f, Y = 16.0f },
+				new() { X =  5.0f, Y = 22.0f },
+				new() { X = 10.0f, Y = 20.0f },
+				new() { X = 15.0f, Y = 21.0f },
+				new() { X = 15.0f, Y = 25.0f },
+				new() { X =  9.0f, Y = 28.0f },
+				new() { X = 13.0f, Y = 29.0f },
+				new() { X =  8.0f, Y = 34.0f },
+				new() { X = 15.0f, Y = 36.0f },
+				new() { X = 16.0f, Y = 32.0f },
+				new() { X = 17.0f, Y = 38.0f },
+			} },
+			{ 04355, new List<PositionInfo>() {							// False Gigantopithecus
+				new() { X = 27.0f, Y = 17.0f },
+				new() { X = 27.0f, Y = 20.0f },
+				new() { X = 24.0f, Y = 23.0f },
+				new() { X = 27.0f, Y = 25.0f },
+				new() { X = 27.0f, Y = 29.0f },
+				new() { X = 26.0f, Y = 37.0f },
+				new() { X = 35.0f, Y = 27.0f },
+				new() { X = 38.0f, Y = 29.0f },
+				new() { X = 34.0f, Y = 24.0f },
+				new() { X = 36.0f, Y = 21.0f },
+				new() { X = 32.0f, Y = 20.0f },
+			} },
 
-		// Kholusia
-		{ 08517, new PositionInfo { X = 31.9f, Y = 18.9f } }, // Ironbeard
-		{ 08518, new PositionInfo { X = 36.4f, Y = 28.7f } }, // Hobgoblin
-		{ 08520, new PositionInfo { X = 17.0f, Y = 18.0f } }, // Defective Talos
-		{ 08522, new PositionInfo { X = 34.8f, Y = 10.5f } }, // Sulfur Byrgen
-		{ 08523, new PositionInfo { X = 35.4f, Y = 29.2f } }, // Maultasche
-		{ 08524, new PositionInfo { X = 14.3f, Y = 11.4f } }, // Huldu
-		{ 08525, new PositionInfo { X = 14.3f, Y = 27.1f } }, // Island Rail
-		{ 08527, new PositionInfo { X = 17.0f, Y = 11.0f } }, // Cliffkite
-		{ 08528, new PositionInfo { X = 27.1f, Y = 13.8f } }, // Cliffmole
-		{ 08529, new PositionInfo { X = 08.0f, Y = 18.0f } }, // Scree Gnome
-		{ 08532, new PositionInfo { X = 17.8f, Y = 26.5f } }, // Wood Eyes
-		{ 08533, new PositionInfo { X = 25.0f, Y = 23.5f } }, // Island Wolf
-		{ 08534, new PositionInfo { X = 10.1f, Y = 29.6f } }, // Kholusian Bison
-		{ 08536, new PositionInfo { X = 32.5f, Y = 26.2f } }, // Whiptail
-		{ 08538, new PositionInfo { X = 22.5f, Y = 09.6f } }, // Highland Hyssop
-		{ 08539, new PositionInfo { X = 19.9f, Y = 33.0f } }, // Tragopan
-		{ 08540, new PositionInfo { X = 13.0f, Y = 15.0f } }, // Saichania
-		{ 08541, new PositionInfo { X = 21.0f, Y = 08.7f } }, // Gulgnu
-		{ 08542, new PositionInfo { X = 21.6f, Y = 32.0f } }, // Germinant
+			// Azys Lla
+			{ 04360, new List<PositionInfo>() {							// Lycidas
+				new() { X = 14.0f, Y = 17.0f },
+				new() { X = 18.0f, Y = 13.0f },
+				new() { X = 17.0f, Y =  9.0f },
+				new() { X = 34.0f, Y = 26.0f },
+				new() { X = 38.0f, Y = 27.0f },
+				new() { X = 36.0f, Y = 31.0f },
+				new() { X = 36.0f, Y = 34.0f },
+				new() { X = 37.0f, Y = 37.0f },
+				new() { X = 30.0f, Y = 35.0f },
+				new() { X = 30.0f, Y = 28.0f },
+				new() { X = 30.0f, Y = 38.0f },
+			} },
+			{ 04361, new List<PositionInfo>() {							// Omni
+				new() { X = 28.0f, Y = 16.0f },
+				new() { X = 28.0f, Y = 11.0f },
+				new() { X = 34.0f, Y = 13.0f },
+				new() { X = 27.0f, Y = 11.0f },
+				new() { X = 33.0f, Y =  6.0f },
+				new() { X = 38.0f, Y =  7.0f },
+				new() { X = 13.0f, Y = 38.0f },
+				new() { X =  8.0f, Y = 34.0f },
+				new() { X = 11.0f, Y = 30.0f },
+				new() { X = 17.0f, Y = 29.0f },
+				new() { X = 10.0f, Y = 27.0f },
+				new() { X = 15.0f, Y = 29.0f },
+			} },
 
-		// Amh Araeng
-		{ 08544, new PositionInfo { X = 11.4f, Y = 30.4f } }, // Masterless Talos
-		{ 08545, new PositionInfo { X = 19.1f, Y = 20.9f } }, // Evil Weapon
-		{ 08547, new PositionInfo { X = 30.4f, Y = 12.3f } }, // Gigantender
-		{ 08550, new PositionInfo { X = 29.4f, Y = 25.4f } }, // Ancient Lizard
-		{ 08556, new PositionInfo { X = 29.4f, Y = 21.7f } }, // Sand Mole
-		{ 08557, new PositionInfo { X = 12.7f, Y = 19.0f } }, // Thistle Mole
-		{ 08558, new PositionInfo { X = 30.9f, Y = 27.3f } }, // Scissorjaws
-		{ 08559, new PositionInfo { X = 21.5f, Y = 09.7f } }, // Gnome
-		{ 08561, new PositionInfo { X = 13.9f, Y = 18.2f } }, // Debitage
-		{ 08562, new PositionInfo { X = 27.1f, Y = 29.6f } }, // Ghilman
-		{ 08563, new PositionInfo { X = 25.0f, Y = 34.3f } }, // Flame Zonure
-		{ 08565, new PositionInfo { X = 15.2f, Y = 16.7f } }, // Phorusrhacos
-		{ 08566, new PositionInfo { X = 21.7f, Y = 09.8f } }, // Desert Coyote
-		{ 08567, new PositionInfo { X = 23.9f, Y = 31.8f } }, // Molamander
+			// Daily Targets
+			// Coerthas Western Highlands
+			{ 03481, new List<PositionInfo>() { new() { X = 15.0f, Y = 12.0f, Radius = 150 } } }, // Archaeornis
+			{ 03472, new List<PositionInfo>() { new() { X = 32.0f, Y = 24.0f, Radius = 150 } } }, // Bergthurs
+			{ 03471, new List<PositionInfo>() { new() { X = 30.0f, Y = 31.0f, Radius = 150 } } }, // Deepeye
+			{ 03476, new List<PositionInfo>() { new() { X = 28.0f, Y = 12.0f, Radius = 150 } } }, // Frost Grenade
+			{ 03480, new List<PositionInfo>() { new() { X = 11.0f, Y = 17.0f, Radius = 150 } } }, // Gelato
+			{ 03484, new List<PositionInfo>() { new() { X = 10.0f, Y = 14.0f, Radius = 150 } } }, // Ice Commander
+			{ 03475, new List<PositionInfo>() { new() { X = 23.0f, Y = 16.0f, Radius = 150 } } }, // Icetrap
+			{ 03487, new List<PositionInfo>() { new() { X = 28.0f, Y = 09.0f, Radius = 150 } } }, // Inland Tursus
+			{ 03483, new List<PositionInfo>() { new() { X = 19.0f, Y = 29.0f, Radius = 150 } } }, // Lone Yeti
+			{ 03485, new List<PositionInfo>() { new() { X = 22.0f, Y = 21.0f, Radius = 150 } } }, // Polar Bear
+			{ 03482, new List<PositionInfo>() { new() { X = 16.0f, Y = 20.0f, Radius = 150 } } }, // Rheum
+			{ 03473, new List<PositionInfo>() { new() { X = 26.0f, Y = 24.0f, Radius = 150 } } }, // Silver Wolf
+			{ 03490, new List<PositionInfo>() { new() { X = 25.0f, Y = 32.0f, Radius = 150 } } }, // Slate Yeti
+			{ 03478, new List<PositionInfo>() { new() { X = 25.0f, Y = 12.0f, Radius = 150 } } }, // Slush Zoblyn
+			{ 03470, new List<PositionInfo>() { new() { X = 30.0f, Y = 32.0f, Radius = 150 } } }, // Steinbock
+			{ 03474, new List<PositionInfo>() { new() { X = 31.0f, Y = 20.0f, Radius = 150 } } }, // Upland Mylodon
+			{ 03493, new List<PositionInfo>() { new() { X = 09.0f, Y = 09.0f, Radius = 150 } } }, // Vindthurs
+			{ 03479, new List<PositionInfo>() { new() { X = 15.0f, Y = 17.0f, Radius = 150 } } }, // Wooly Yak
 
-		// Il Mheg
-		{ 08155, new PositionInfo { X = 08.4f, Y = 30.0f } }, // Flower Basket
-		{ 08569, new PositionInfo { X = 18.0f, Y = 31.0f } }, // Echevore
-		{ 08574, new PositionInfo { X = 31.0f, Y = 14.3f } }, // Garden Porxie
-		{ 08575, new PositionInfo { X = 19.9f, Y = 16.3f } }, // Phooka
-		{ 08576, new PositionInfo { X = 11.1f, Y = 26.0f } }, // Etainmoth
-		{ 08577, new PositionInfo { X = 29.4f, Y = 12.7f } }, // Green Glider
-		{ 08578, new PositionInfo { X = 21.0f, Y = 08.8f } }, // Moss Fungus
-		{ 08581, new PositionInfo { X = 07.8f, Y = 18.7f } }, // Hawker
-		{ 08582, new PositionInfo { X = 25.0f, Y = 11.0f } }, // Rainbow Lorikeet
-		{ 08583, new PositionInfo { X = 29.5f, Y = 11.4f } }, // Tot Aevis
-		{ 08584, new PositionInfo { X = 30.4f, Y = 10.6f } }, // Rabbit's Tail
-		{ 08585, new PositionInfo { X = 19.0f, Y = 32.0f } }, // Rosebear
-		{ 08586, new PositionInfo { X = 31.6f, Y = 06.4f } }, // Garden Crocota
-		{ 08587, new PositionInfo { X = 32.0f, Y = 05.8f } }, // Werewood
-		{ 08590, new PositionInfo { X = 09.4f, Y = 15.0f } }, // Killer Bee
+			// The Sea of Clouds
+			{ 03524, new List<PositionInfo>() { new() { X = 21.0f, Y = 06.0f, Radius = 150 } } }, // Anzu
+			{ 03498, new List<PositionInfo>() { new() { X = 28.0f, Y = 29.0f, Radius = 150 } } }, // Cloudworm
+			{ 03496, new List<PositionInfo>() { new() { X = 27.0f, Y = 30.0f, Radius = 150 } } }, // Conodont
+			{ 03505, new List<PositionInfo>() { new() { X = 19.0f, Y = 30.0f, Radius = 150 } } }, // Dhalmel
+			{ 03511, new List<PositionInfo>() { new() { X = 17.0f, Y = 10.0f, Radius = 150 } } }, // Endymion
+			{ 03494, new List<PositionInfo>() { new() { X = 11.0f, Y = 33.0f, Radius = 150 } } }, // Gaelicat
+			{ 03495, new List<PositionInfo>() { new() { X = 16.0f, Y = 36.0f, Radius = 150 } } }, // Gastornis
+			{ 03512, new List<PositionInfo>() { new() { X = 23.0f, Y = 09.0f, Radius = 150 } } }, // Groundskeeper
+			{ 03506, new List<PositionInfo>() { new() { X = 20.0f, Y = 30.0f, Radius = 150 } } }, // Korrigan
+			{ 03501, new List<PositionInfo>() { new() { X = 36.0f, Y = 24.0f, Radius = 150 } } }, // Lan'laii Gundu
+			{ 03502, new List<PositionInfo>() { new() { X = 36.0f, Y = 20.0f, Radius = 150 } } }, // Nat'laii Gundu
+			{ 03516, new List<PositionInfo>() { new() { X = 28.0f, Y = 10.0f, Radius = 150 } } }, // Nat'laii Vundu
+			{ 03497, new List<PositionInfo>() { new() { X = 29.0f, Y = 30.0f, Radius = 150 } } }, // Obdella
+			{ 03499, new List<PositionInfo>() { new() { X = 20.0f, Y = 34.0f, Radius = 150 } } }, // Paissa
+			{ 03500, new List<PositionInfo>() { new() { X = 36.0f, Y = 24.0f, Radius = 150 } } }, // Sanuwa
+			{ 03514, new List<PositionInfo>() { new() { X = 30.0f, Y = 14.0f, Radius = 150 } } }, // Sanuwa Vundu
+			{ 03525, new List<PositionInfo>() { new() { X = 21.0f, Y = 07.0f, Radius = 150 } } }, // Toco Toco
+			{ 03523, new List<PositionInfo>() { new() { X = 14.0f, Y = 07.0f, Radius = 150 } } }, // Tsanahale
+			{ 03503, new List<PositionInfo>() { new() { X = 35.0f, Y = 25.0f, Radius = 150 } } }, // Vuk'laii Gundu
+			{ 03513, new List<PositionInfo>() { new() { X = 18.0f, Y = 17.0f, Radius = 150 } } }, // Vundu Totem
+			{ 03509, new List<PositionInfo>() { new() { X = 09.0f, Y = 16.0f, Radius = 150 } } }, // Window Wamoura
+			{ 03510, new List<PositionInfo>() { new() { X = 10.0f, Y = 17.0f, Radius = 150 } } }, // Window Wamouracampa
+			{ 03504, new List<PositionInfo>() { new() { X = 20.0f, Y = 38.0f, Radius = 150 } } }, // Wisent
 
-		// The Rak'tika Greatwood
-		{ 08596, new PositionInfo { X = 08.8f, Y = 35.6f } }, // Tomatl
-		{ 08597, new PositionInfo { X = 27.3f, Y = 25.6f } }, // Forest Echo
-		{ 08598, new PositionInfo { X = 25.1f, Y = 14.2f } }, // Cracked Ronkan Doll
-		{ 08599, new PositionInfo { X = 23.0f, Y = 14.0f } }, // Cracked Ronkan Thorn
-		{ 08600, new PositionInfo { X = 16.0f, Y = 32.0f } }, // Vampire Vine
-		{ 08601, new PositionInfo { X = 23.4f, Y = 07.6f } }, // Greatwood Rail
-		{ 08603, new PositionInfo { X = 29.4f, Y = 21.7f } }, // Snapweed
-		{ 08604, new PositionInfo { X = 12.0f, Y = 34.0f } }, // Atrociraptor
-		{ 08606, new PositionInfo { X = 27.7f, Y = 23.2f } }, // Gizamaluk
-		{ 08609, new PositionInfo { X = 16.9f, Y = 33.3f } }, // Helm Beetle
-		{ 08610, new PositionInfo { X = 34.1f, Y = 16.5f } }, // Floor Mandrill
-		{ 08611, new PositionInfo { X = 15.0f, Y = 19.4f } }, // Wild Swine
-		{ 08612, new PositionInfo { X = 24.9f, Y = 30.2f } }, // Caracal
-		{ 08614, new PositionInfo { X = 25.0f, Y = 07.2f } }, // Woodbat
-		{ 08616, new PositionInfo { X = 27.9f, Y = 21.2f } }, // Tarichuk
-		{ 08789, new PositionInfo { X = 21.1f, Y = 13.2f } }, // Cracked Ronkan Vessel
+			// The Dravanian Forelands
+			{ 03565, new List<PositionInfo>() { new() { X = 30.0f, Y = 16.0f, Radius = 150 } } }, // Bandersnatch
+			{ 03566, new List<PositionInfo>() { new() { X = 26.0f, Y = 11.0f, Radius = 150 } } }, // Brown Bear
+			{ 03570, new List<PositionInfo>() { new() { X = 28.0f, Y = 22.0f, Radius = 150 } } }, // Clearwater Nanka
+			{ 03569, new List<PositionInfo>() { new() { X = 27.0f, Y = 25.0f, Radius = 150 } } }, // Clearwater Ninki Nanka
+			{ 03572, new List<PositionInfo>() { new() { X = 28.0f, Y = 32.0f, Radius = 150 } } }, // Dragonfly Watcher
+			{ 03567, new List<PositionInfo>() { new() { X = 27.0f, Y = 22.0f, Radius = 150 } } }, // Dravanian Aevis
+			{ 03576, new List<PositionInfo>() { new() { X = 16.0f, Y = 33.0f, Radius = 150 } } }, // Dravanian Wyvern
+			{ 03563, new List<PositionInfo>() { new() { X = 36.0f, Y = 24.0f, Radius = 150 } } }, // Feather Flea
+			{ 03578, new List<PositionInfo>() { new() { X = 17.0f, Y = 26.0f, Radius = 150 } } }, // Forelands Hippocerf
+			{ 03579, new List<PositionInfo>() { new() { X = 18.0f, Y = 12.0f, Radius = 150 } } }, // Gallimimus
+			{ 03571, new List<PositionInfo>() { new() { X = 25.0f, Y = 29.0f, Radius = 150 } } }, // Loaghtan
+			{ 03592, new List<PositionInfo>() { new() { X = 27.0f, Y = 35.0f, Radius = 150 } } }, // Loth Cultivator
+			{ 03590, new List<PositionInfo>() { new() { X = 27.0f, Y = 35.0f, Radius = 150 } } }, // Loth Firedrone
+			{ 03591, new List<PositionInfo>() { new() { X = 29.0f, Y = 36.0f, Radius = 150 } } }, // Loth Steeldrone
+			{ 03568, new List<PositionInfo>() { new() { X = 28.0f, Y = 25.0f, Radius = 150 } } }, // Melia
+			{ 03577, new List<PositionInfo>() { new() { X = 18.0f, Y = 31.0f, Radius = 150 } } }, // Miacid
+			{ 03555, new List<PositionInfo>() { new() { X = 18.0f, Y = 12.0f, Radius = 150 } } }, // Syricta
+			{ 03586, new List<PositionInfo>() { new() { X = 31.0f, Y = 08.0f, Radius = 150 } } }, // Thunder Dragon
+			{ 03582, new List<PositionInfo>() { new() { X = 13.0f, Y = 15.0f, Radius = 150 } } }, // Tyrannosaur
+			{ 03581, new List<PositionInfo>() { new() { X = 13.0f, Y = 14.0f, Radius = 150 } } }, // Vinegaroon
+			{ 03564, new List<PositionInfo>() { new() { X = 35.0f, Y = 21.0f, Radius = 150 } } }, // Wild Chocobo
 
-		// The Tempest
-		{ 08618, new PositionInfo { X = 28.6f, Y = 06.2f } }, // Clinoid
-		{ 08619, new PositionInfo { X = 28.2f, Y = 18.3f } }, // Dagon
-		{ 08621, new PositionInfo { X = 22.6f, Y = 31.7f } }, // Cubus
-		{ 08622, new PositionInfo { X = 25.1f, Y = 18.6f } }, // Sea Anemone
-		{ 08623, new PositionInfo { X = 32.1f, Y = 11.7f } }, // Amphisbaena
-		{ 08625, new PositionInfo { X = 32.5f, Y = 21.5f } }, // Morgawr
-		{ 08626, new PositionInfo { X = 36.6f, Y = 16.6f } }, // Trilobite
-		{ 08629, new PositionInfo { X = 27.7f, Y = 08.7f } }, // Sea Gelatin
-		{ 08630, new PositionInfo { X = 29.0f, Y = 21.0f } }, // Tempest Swallow
-		{ 08631, new PositionInfo { X = 35.8f, Y = 07.2f } }, // Blue Swimmer
+			// The Churning Mists
+			{ 03619, new List<PositionInfo>() { new() { X = 17.0f, Y = 27.0f, Radius = 150 } } }, // Amphiptere
+			{ 03620, new List<PositionInfo>() { new() { X = 24.0f, Y = 26.0f, Radius = 150 } } }, // Archaeosaur
+			{ 03625, new List<PositionInfo>() { new() { X = 18.0f, Y = 24.0f, Radius = 150 } } }, // Bladed Vinegaroon
+			{ 03630, new List<PositionInfo>() { new() { X = 25.0f, Y = 10.0f, Radius = 150 } } }, // Blood Dragon
+			{ 03631, new List<PositionInfo>() { new() { X = 09.0f, Y = 36.0f, Radius = 150 } } }, // Cloud Aevis
+			{ 03629, new List<PositionInfo>() { new() { X = 08.0f, Y = 19.0f, Radius = 150 } } }, // Diresaur
+			{ 03623, new List<PositionInfo>() { new() { X = 20.0f, Y = 12.0f, Radius = 150 } } }, // Dragonet
+			{ 03626, new List<PositionInfo>() { new() { X = 34.0f, Y = 21.0f, Radius = 150 } } }, // Elder Syricta
+			{ 03628, new List<PositionInfo>() { new() { X = 25.0f, Y = 30.0f, Radius = 150 } } }, // Elder Wyvern
+			{ 03668, new List<PositionInfo>() { new() { X = 10.0f, Y = 20.0f, Radius = 150 } } }, // Gnarled Melia
+			{ 03614, new List<PositionInfo>() { new() { X = 34.0f, Y = 28.0f, Radius = 150 } } }, // Hropken
+			{ 03621, new List<PositionInfo>() { new() { X = 09.0f, Y = 12.0f, Radius = 150 } } }, // Limestone Golem
+			{ 03618, new List<PositionInfo>() { new() { X = 20.0f, Y = 28.0f, Radius = 150 } } }, // Lower Skylord
+			{ 03627, new List<PositionInfo>() { new() { X = 33.0f, Y = 31.0f, Radius = 150 } } }, // Mists Biast
+			{ 03622, new List<PositionInfo>() { new() { X = 10.0f, Y = 18.0f, Radius = 150 } } }, // Mists Drake
+			{ 03617, new List<PositionInfo>() { new() { X = 23.0f, Y = 25.0f, Radius = 150 } } }, // Moss Dragon
+			{ 03613, new List<PositionInfo>() { new() { X = 28.0f, Y = 32.0f, Radius = 150 } } }, // Sankchinni
+			{ 03615, new List<PositionInfo>() { new() { X = 32.0f, Y = 15.0f, Radius = 150 } } }, // Tulihand
+			{ 03624, new List<PositionInfo>() { new() { X = 38.0f, Y = 17.7f, Radius = 150 } } }, // Vouivre
+			{ 03616, new List<PositionInfo>() { new() { X = 26.0f, Y = 20.0f, Radius = 150 } } }, // Wadjet
 
-		// Endwalker
-		// Labyrinthos
-		{ 10668, new PositionInfo { X = 28.8f, Y = 08.8f } }, // Troll
-		{ 10669, new PositionInfo { X = 31.0f, Y = 25.5f } }, // Genomos
-		{ 10670, new PositionInfo { X = 15.0f, Y = 06.5f } }, // Caribou
-		{ 10672, new PositionInfo { X = 32.0f, Y = 08.8f } }, // Limascabra
-		{ 10673, new PositionInfo { X = 21.5f, Y = 13.5f } }, // Luncheon Toad
-		{ 10674, new PositionInfo { X = 17.0f, Y = 12.0f } }, // Yakow
-		{ 10677, new PositionInfo { X = 34.0f, Y = 15.0f } }, // Labyrinth Screamer
-		{ 10678, new PositionInfo { X = 24.0f, Y = 10.7f } }, // Northern Snapweed
-		{ 10679, new PositionInfo { X = 26.0f, Y = 14.5f } }, // Pephredo
-		{ 10683, new PositionInfo { X = 37.5f, Y = 19.5f } }, // Mythrilcap
+			// The Dravanian Hinterlands
+			{ 03612, new List<PositionInfo>() { new() { X = 25.0f, Y = 37.0f, Radius = 150 } } }, // Bifericeras
+			{ 03609, new List<PositionInfo>() { new() { X = 18.0f, Y = 36.0f, Radius = 150 } } }, // Cockatrice
+			{ 03603, new List<PositionInfo>() { new() { X = 12.0f, Y = 16.0f, Radius = 150 } } }, // Crawler
+			{ 03594, new List<PositionInfo>() { new() { X = 24.0f, Y = 21.0f, Radius = 150 } } }, // Damselfly
+			{ 03598, new List<PositionInfo>() { new() { X = 31.0f, Y = 22.0f, Radius = 150 } } }, // Goblin Brandisher
+			{ 03601, new List<PositionInfo>() { new() { X = 31.0f, Y = 22.0f, Radius = 150 } } }, // Goblin Glider
+			{ 03600, new List<PositionInfo>() { new() { X = 31.0f, Y = 22.0f, Radius = 150 } } }, // Goblin Sharpshooter
+			{ 03599, new List<PositionInfo>() { new() { X = 31.0f, Y = 22.0f, Radius = 150 } } }, // Goblin Tinkerer
+			{ 03605, new List<PositionInfo>() { new() { X = 10.0f, Y = 21.0f, Radius = 150 } } }, // Great Morbol
+			{ 03597, new List<PositionInfo>() { new() { X = 37.0f, Y = 24.0f, Radius = 150 } } }, // Narbrooi
+			{ 03610, new List<PositionInfo>() { new() { X = 17.0f, Y = 33.0f, Radius = 150 } } }, // Okeanis
+			{ 03608, new List<PositionInfo>() { new() { X = 12.0f, Y = 33.0f, Radius = 150 } } }, // Opken
+			{ 03604, new List<PositionInfo>() { new() { X = 11.0f, Y = 27.0f, Radius = 150 } } }, // Orn Kite
+			{ 03607, new List<PositionInfo>() { new() { X = 09.0f, Y = 34.0f, Radius = 150 } } }, // Poroggo
+			{ 03595, new List<PositionInfo>() { new() { X = 28.0f, Y = 27.0f, Radius = 150 } } }, // Ratel
+			{ 03611, new List<PositionInfo>() { new() { X = 12.0f, Y = 32.0f, Radius = 150 } } }, // Sun Leech
+			{ 03593, new List<PositionInfo>() { new() { X = 21.0f, Y = 16.0f, Radius = 150 } } }, // Tarantula Hawk
+			{ 03596, new List<PositionInfo>() { new() { X = 34.0f, Y = 19.0f, Radius = 150 } } }, // Wildebeest
 
-		// Thavnair
-		{ 10697, new PositionInfo { X = 19.0f, Y = 23.9f } }, // Pisaca
-		{ 10698, new PositionInfo { X = 13.8f, Y = 18.5f } }, // Vajralangula
-		{ 10699, new PositionInfo { X = 19.2f, Y = 32.6f } }, // Kacchapa
-		{ 10700, new PositionInfo { X = 18.4f, Y = 26.7f } }, // Hamsa
-		{ 10701, new PositionInfo { X = 29.1f, Y = 12.2f } }, // Asvattha
-		{ 10702, new PositionInfo { X = 27.1f, Y = 27.8f } }, // Guhasaya
-		{ 10703, new PositionInfo { X = 27.0f, Y = 17.4f } }, // Bhujamga
-		{ 10704, new PositionInfo { X = 17.6f, Y = 17.8f } }, // Sotormurg
-		{ 10705, new PositionInfo { X = 22.7f, Y = 30.4f } }, // Gaja
-		{ 10706, new PositionInfo { X = 19.1f, Y = 11.7f } }, // Thavnairian Jhammel
-		{ 10707, new PositionInfo { X = 25.9f, Y = 19.0f } }, // Ufiti
-		{ 10709, new PositionInfo { X = 09.2f, Y = 12.8f } }, // Chamrosh
-		{ 10711, new PositionInfo { X = 16.1f, Y = 09.2f } }, // Starmite
-		{ 10712, new PositionInfo { X = 14.3f, Y = 12.7f } }, // Manjusaka
-		{ 10713, new PositionInfo { X = 23.3f, Y = 19.9f } }, // Odqan
-		{ 10715, new PositionInfo { X = 13.4f, Y = 28.5f } }, // Akyaali Crab
-		{ 10716, new PositionInfo { X = 08.2f, Y = 16.2f } }, // Valras
+			// Azys Lla
+			{ 03545, new List<PositionInfo>() { new() { X = 35.0f, Y = 24.0f, Radius = 150 } } }, // 6th Legion Vanguard
+			{ 03552, new List<PositionInfo>() { new() { X = 27.0f, Y = 33.0f, Radius = 150 } } }, // Adamantite Claw
+			{ 03540, new List<PositionInfo>() { new() { X = 31.0f, Y = 06.0f, Radius = 150 } } }, // Allagan Chimera
+			{ 03534, new List<PositionInfo>() { new() { X = 15.0f, Y = 13.0f, Radius = 150 } } }, // Clockwork Engineer
+			{ 03536, new List<PositionInfo>() { new() { X = 13.0f, Y = 08.0f, Radius = 150 } } }, // Clockwork Harvestman
+			{ 03535, new List<PositionInfo>() { new() { X = 18.0f, Y = 13.0f, Radius = 150 } } }, // Clockwork Paladin
+			{ 03542, new List<PositionInfo>() { new() { X = 35.0f, Y = 09.0f, Radius = 150 } } }, // Corpse Flower
+			{ 03541, new List<PositionInfo>() { new() { X = 29.5f, Y = 12.0f, Radius = 150 } } }, // Empuse
+			{ 03537, new List<PositionInfo>() { new() { X = 13.0f, Y = 17.0f, Radius = 150 } } }, // Enforcement Droid
+			{ 03539, new List<PositionInfo>() { new() { X = 27.0f, Y = 11.0f, Radius = 150 } } }, // Lamia Cybrid
+			{ 03538, new List<PositionInfo>() { new() { X = 28.0f, Y = 13.0f, Radius = 150 } } }, // Lamia Thelytoke
+			{ 03580, new List<PositionInfo>() { new() { X = 13.0f, Y = 33.0f, Radius = 150 } } }, // Lesser Hydra
+			{ 03559, new List<PositionInfo>() { new() { X = 18.0f, Y = 31.0f, Radius = 150 } } }, // Meracydian Amphiptere
+			{ 03557, new List<PositionInfo>() { new() { X = 08.0f, Y = 32.0f, Radius = 150 } } }, // Meracydian Brobinyak
+			{ 03560, new List<PositionInfo>() { new() { X = 08.0f, Y = 27.0f, Radius = 150 } } }, // Meracydian Dragon
+			{ 03558, new List<PositionInfo>() { new() { X = 06.0f, Y = 35.0f, Radius = 150 } } }, // Meracydian Dragonet
+			{ 03554, new List<PositionInfo>() { new() { X = 15.0f, Y = 29.0f, Radius = 150 } } }, // Meracydian Falak
+			{ 03556, new List<PositionInfo>() { new() { X = 14.0f, Y = 35.0f, Radius = 150 } } }, // Meracydian Vouivre
+			{ 03533, new List<PositionInfo>() { new() { X = 12.0f, Y = 15.0f, Radius = 150 } } }, // Owlbear
+			{ 03543, new List<PositionInfo>() { new() { X = 35.0f, Y = 08.0f, Radius = 150 } } }, // Proto-naga
+			{ 03544, new List<PositionInfo>() { new() { X = 33.0f, Y = 13.0f, Radius = 150 } } }, // Reptoid
+			{ 03532, new List<PositionInfo>() { new() { X = 09.0f, Y = 12.0f, Radius = 150 } } }, // Snapper-rook
 
-		// Garlemald
-		{ 10648, new PositionInfo { X = 18.8f, Y = 09.8f } }, // Automated Satellite
-		{ 10649, new PositionInfo { X = 25.5f, Y = 17.5f } }, // Automated Death Machine
-		{ 10650, new PositionInfo { X = 15.5f, Y = 19.5f } }, // Automated Cavalry
-		{ 10651, new PositionInfo { X = 21.8f, Y = 17.4f } }, // Automated Bit
-		{ 10652, new PositionInfo { X = 15.7f, Y = 09.8f } }, // Automated Roader
-		{ 10653, new PositionInfo { X = 29.5f, Y = 13.7f } }, // Automated Slasher
-		{ 10654, new PositionInfo { X = 24.3f, Y = 14.9f } }, // Automated Colossus
-		{ 10655, new PositionInfo { X = 12.9f, Y = 11.7f } }, // Automated Avenger
-		{ 10656, new PositionInfo { X = 29.6f, Y = 30.3f } }, // Almasty
-		{ 10657, new PositionInfo { X = 14.6f, Y = 26.1f } }, // Eblan Bear
-		{ 10658, new PositionInfo { X = 31.3f, Y = 17.4f } }, // Eblan Icetrap
-		{ 10659, new PositionInfo { X = 19.8f, Y = 29.1f } }, // Ovibos
-		{ 10660, new PositionInfo { X = 22.3f, Y = 24.9f } }, // Jotunn
-		{ 10661, new PositionInfo { X = 28.4f, Y = 33.0f } }, // Ceruleum Zoblyn
-		{ 10662, new PositionInfo { X = 25.4f, Y = 31.5f } }, // Ilsabardian Tursus
-		{ 10663, new PositionInfo { X = 18.7f, Y = 24.8f } }, // Canis Lupinus
-		{ 10664, new PositionInfo { X = 26.1f, Y = 26.5f } }, // Overgrown Rose
 
-		// Mare Lamentorum
-		{ 10458, new PositionInfo { X = 23.9f, Y = 20.0f } }, // Daphnia
-		{ 10459, new PositionInfo { X = 23.7f, Y = 20.3f } }, // Osculator
-		{ 10460, new PositionInfo { X = 08.6f, Y = 35.5f } }, // Sweeper
-		{ 10461, new PositionInfo { X = 27.3f, Y = 26.0f } }, // Wanderer
-		{ 10462, new PositionInfo { X = 31.1f, Y = 32.2f } }, // Weeper
-		{ 10463, new PositionInfo { X = 19.8f, Y = 22.5f } }, // Thinker
-		{ 10464, new PositionInfo { X = 26.0f, Y = 34.0f } }, // Regolith
-		{ 10465, new PositionInfo { X = 21.4f, Y = 32.2f } }, // Trimmer
-		{ 10467, new PositionInfo { X = 12.0f, Y = 36.7f } }, // Panopt
-		{ 10468, new PositionInfo { X = 11.5f, Y = 22.3f } }, // Dynamite
-		{ 10469, new PositionInfo { X = 16.7f, Y = 31.8f } }, // Armalcolite
-		{ 10470, new PositionInfo { X = 12.9f, Y = 09.6f } }, // Caretaker
-		{ 10471, new PositionInfo { X = 16.1f, Y = 24.9f } }, // Mousse
-		{ 10473, new PositionInfo { X = 31.2f, Y = 27.0f } }, // Downfall Alarum
-		{ 10474, new PositionInfo { X = 33.6f, Y = 26.2f } }, // Downfall Droid
-		{ 10475, new PositionInfo { X = 34.5f, Y = 28.0f } }, // Downfall Hunter
-		{ 10476, new PositionInfo { X = 13.0f, Y = 10.0f } }, // Supporter
-		{ 10477, new PositionInfo { X = 30.1f, Y = 11.0f } }, // Scraper
+			// Stormblood
+			// B Rank
+			// The Fringes
+			{ 06008, new List<PositionInfo>() {                         // Shadow-dweller Yamini
+				new() { X = 33.0f, Y = 33.0f },
+				new() { X = 29.0f, Y = 30.0f },
+				new() { X = 25.0f, Y = 32.0f },
+				new() { X = 25.0f, Y = 28.0f },
+				new() { X = 28.0f, Y = 23.0f },
+				new() { X = 33.0f, Y = 20.0f },
+				new() { X = 34.0f, Y = 17.0f },
+			} },
+			{ 06009, new List<PositionInfo>() {							// Ouzelum
+				new() { X = 10.0f, Y = 14.0f },
+				new() { X = 14.0f, Y = 12.0f },
+				new() { X = 17.0f, Y = 12.0f },
+				new() { X = 18.0f, Y =  8.0f },
+				new() { X = 21.0f, Y = 10.0f },
+				new() { X = 25.0f, Y = 11.0f },
+				new() { X = 24.0f, Y = 18.0f },
+				new() { X = 17.0f, Y = 21.0f },
+				new() { X = 16.0f, Y = 23.0f },
+				new() { X = 15.0f, Y = 26.0f },
+				new() { X =  8.0f, Y = 30.0f },
+				new() { X =  8.0f, Y = 24.0f },
+				new() { X = 12.0f, Y = 18.0f },
+			} },
+			// The Peaks
+			{ 06004, new List<PositionInfo>() {							// Deidar
+				new() { X = 32.0f, Y = 18.0f },
+				new() { X = 24.0f, Y = 22.0f },
+				new() { X = 23.0f, Y = 27.0f },
+				new() { X = 34.0f, Y = 26.0f },
+				new() { X = 30.0f, Y = 34.0f },
+				new() { X = 17.0f, Y = 34.0f },
+				new() { X = 12.0f, Y = 30.0f },
+			} },
+			{ 06005, new List<PositionInfo>() {							// Gyorai Quickstrike
+				new() { X = 28.0f, Y = 11.0f },
+				new() { X = 27.0f, Y = 10.0f },
+				new() { X = 23.0f, Y = 11.0f },
+				new() { X = 21.0f, Y =  9.0f },
+				new() { X = 18.0f, Y = 10.0f },
+				new() { X = 17.0f, Y = 14.0f },
+				new() { X = 18.0f, Y = 16.0f },
+			} },
+			// The Ruby Sea
+			{ 06003, new List<PositionInfo>() {							// Guhuo Niao
+				new() { X =  7.0f, Y =  5.0f },
+				new() { X = 17.0f, Y = 11.0f },
+				new() { X = 18.0f, Y =  8.0f },
+				new() { X = 26.0f, Y =  6.0f },
+				new() { X = 36.0f, Y = 18.0f },
+				new() { X = 34.0f, Y = 21.0f },
+				new() { X = 32.0f, Y = 24.0f },
+			} },
+			{ 06002, new List<PositionInfo>() {							// Gauki Strongblade
+				new() { X = 32.0f, Y = 37.0f },
+				new() { X = 24.0f, Y = 32.0f },
+				new() { X = 27.0f, Y = 30.0f },
+				new() { X = 24.0f, Y = 26.0f },
+				new() { X = 14.0f, Y = 14.0f },
+				new() { X =  4.0f, Y = 22.0f },
+				new() { X =  6.0f, Y = 29.0f },
+			} },
+			// Yanxia
+			{ 06010, new List<PositionInfo>() {							// Gwas-y-neidr
+				new() { X =  5.0f, Y = 35.0f },
+				new() { X = 11.0f, Y = 32.0f },
+				new() { X =  7.0f, Y = 25.0f },
+				new() { X = 12.0f, Y = 28.0f },
+				new() { X = 17.0f, Y = 27.0f },
+				new() { X = 16.0f, Y = 22.0f },
+				new() { X = 23.0f, Y = 24.0f },
+				new() { X = 27.0f, Y = 29.0f },
+				new() { X = 23.0f, Y = 36.0f },
+			} },
+			{ 06011, new List<PositionInfo>() {							// Buccaboo
+				new() { X = 11.0f, Y =  7.0f },
+				new() { X =  9.0f, Y = 11.0f },
+				new() { X =  6.0f, Y = 14.0f },
+				new() { X = 25.0f, Y =  8.0f },
+				new() { X = 32.0f, Y =  7.0f },
+				new() { X = 36.0f, Y = 12.0f },
+				new() { X = 26.0f, Y = 11.0f },
+				new() { X = 23.0f, Y = 14.0f },
+				new() { X = 25.0f, Y = 20.0f },
+			} },
+			// The Azim Steppe
+			{ 06007, new List<PositionInfo>() {							// Aswang
+				new() { X = 28.0f, Y = 26.0f },
+				new() { X = 28.0f, Y = 18.0f },
+				new() { X = 22.0f, Y = 16.0f },
+				new() { X = 17.0f, Y = 18.0f },
+				new() { X = 12.0f, Y = 17.0f },
+				new() { X = 13.0f, Y =  9.0f },
+				new() { X = 19.0f, Y = 10.0f },
+				new() { X = 27.0f, Y =  8.0f },
+				new() { X = 35.0f, Y = 15.0f },
+			} },
+			{ 06006, new List<PositionInfo>() {							// Kurma
+				new() { X = 24.0f, Y = 30.0f },
+				new() { X = 26.0f, Y = 34.0f },
+				new() { X = 21.0f, Y = 34.0f },
+				new() { X = 17.0f, Y = 33.0f },
+				new() { X = 14.0f, Y = 30.0f },
+				new() { X = 15.0f, Y = 26.0f },
+				new() { X = 11.0f, Y = 28.0f },
+				new() { X =  9.0f, Y = 25.0f },
+				new() { X =  9.0f, Y = 22.0f },
+			} },
+			// The Lochs
+			{ 06013, new List<PositionInfo>() {							// Kiwa
+				new() { X = 14.0f, Y = 20.0f },
+				new() { X = 15.0f, Y = 21.0f },
+				new() { X = 25.0f, Y = 17.0f },
+				new() { X = 18.0f, Y = 26.0f },
+				new() { X = 24.0f, Y = 26.0f },
+				new() { X = 19.0f, Y = 32.0f },
+				new() { X = 25.0f, Y = 33.0f },
+			} },
+			{ 06012, new List<PositionInfo>() {							// Manes
+				new() { X = 30.0f, Y = 36.0f },
+				new() { X = 27.0f, Y = 34.0f },
+				new() { X = 10.0f, Y = 34.0f },
+				new() { X =  6.0f, Y = 31.0f },
+				new() { X =  4.0f, Y = 28.0f },
+				new() { X =  7.0f, Y = 26.0f },
+				new() { X =  7.0f, Y = 13.0f },
+				new() { X =  6.0f, Y =  8.0f },
+				new() { X = 18.0f, Y =  7.0f },
+				new() { X = 22.0f, Y = 10.0f },
+				new() { X = 28.0f, Y =  7.0f },
+				new() { X = 35.0f, Y = 11.0f },
+				new() { X = 23.0f, Y = 11.0f },
+			} },
 
-		// Elpis
-		{ 10590, new PositionInfo { X = 25.7f, Y = 33.9f } }, // Ophion
-		{ 10591, new PositionInfo { X = 16.5f, Y = 29.9f } }, // Yggdreant
-		{ 10592, new PositionInfo { X = 22.6f, Y = 20.0f } }, // Okyupete
-		{ 10594, new PositionInfo { X = 12.4f, Y = 31.8f } }, // Gryps
-		{ 10595, new PositionInfo { X = 26.6f, Y = 29.7f } }, // Monoceros
-		{ 10596, new PositionInfo { X = 10.1f, Y = 14.1f } }, // Pegasos
-		{ 10597, new PositionInfo { X = 28.7f, Y = 25.6f } }, // Bird of Elpis
-		{ 10599, new PositionInfo { X = 33.4f, Y = 14.3f } }, // Hippe
-		{ 10600, new PositionInfo { X = 14.1f, Y = 09.9f } }, // Harpuia
-		{ 10601, new PositionInfo { X = 25.0f, Y = 10.0f } }, // Morbol Marquis
-		{ 10602, new PositionInfo { X = 29.2f, Y = 09.3f } }, // Akantha
-		{ 10603, new PositionInfo { X = 24.4f, Y = 14.3f } }, // Lykopersikon
-		{ 10606, new PositionInfo { X = 21.5f, Y = 06.3f } }, // Lotis
-		{ 10607, new PositionInfo { X = 10.2f, Y = 34.6f } }, // Phanopsyche
-		{ 10608, new PositionInfo { X = 12.9f, Y = 23.4f } }, // Melanion
-		{ 10609, new PositionInfo { X = 12.9f, Y = 08.7f } }, // Ophiotauros
-		{ 10610, new PositionInfo { X = 13.3f, Y = 15.7f } }, // Elpis Minotaur
-		{ 10611, new PositionInfo { X = 30.7f, Y = 17.1f } }, // Remora
+			// Daily Targets
+			// The Fringes
+			{ 05685, new List<PositionInfo>() { new() { X = 10.0f, Y = 27.0f, Radius = 150 } } }, // Diakka
+			{ 05674, new List<PositionInfo>() { new() { X = 22.0f, Y = 16.0f, Radius = 150 } } }, // Foper
+			{ 05697, new List<PositionInfo>() { new() { X = 25.0f, Y = 27.0f, Radius = 150 } } }, // Gazelle
+			{ 05676, new List<PositionInfo>() { new() { X = 11.6f, Y = 12.0f, Radius = 150 } } }, // Gazelle Hawk
+			{ 05679, new List<PositionInfo>() { new() { X = 25.0f, Y = 15.0f, Radius = 150 } } }, // Gelid Bhoot
+			{ 05686, new List<PositionInfo>() { new() { X = 10.0f, Y = 27.0f, Radius = 150 } } }, // Goosefish
+			{ 05671, new List<PositionInfo>() { new() { X = 11.0f, Y = 11.0f, Radius = 150 } } }, // Leshy
+			{ 05687, new List<PositionInfo>() { new() { X = 11.0f, Y = 17.0f, Radius = 150 } } }, // Mossling
+			{ 05683, new List<PositionInfo>() { new() { X = 12.0f, Y = 17.0f, Radius = 150 } } }, // Mountain Grizzly
+			{ 05691, new List<PositionInfo>() { new() { X = 35.0f, Y = 25.0f, Radius = 150 } } }, // Qalyana Brahmin
+			{ 05689, new List<PositionInfo>() { new() { X = 35.0f, Y = 25.0f, Radius = 150 } } }, // Qalyana Kshatriya
+			{ 05690, new List<PositionInfo>() { new() { X = 35.0f, Y = 25.0f, Radius = 150 } } }, // Qalyana Shudra
+			{ 05688, new List<PositionInfo>() { new() { X = 35.0f, Y = 25.0f, Radius = 150 } } }, // Sacred Marid
+			{ 05675, new List<PositionInfo>() { new() { X = 10.0f, Y = 12.0f, Radius = 150 } } }, // Sapria
+			{ 05677, new List<PositionInfo>() { new() { X = 22.0f, Y = 11.0f, Radius = 150 } } }, // Spinner
+			{ 05693, new List<PositionInfo>() { new() { X = 29.0f, Y = 24.0f, Radius = 150 } } }, // Teleoceras
+			{ 05678, new List<PositionInfo>() { new() { X = 28.0f, Y = 15.0f, Radius = 150 } } }, // Velodyna Pugil
+			{ 05680, new List<PositionInfo>() { new() { X = 17.0f, Y = 10.0f, Radius = 150 } } }, // Velodyna Sarcosuchus
 
-		// Ultima Thule
-		{ 10419, new PositionInfo { X = 30.1f, Y = 25.9f } }, // Broken Omicron
-		{ 10420, new PositionInfo { X = 19.3f, Y = 11.8f } }, // Drifting Ea
-		{ 10421, new PositionInfo { X = 34.8f, Y = 28.8f } }, // Beta
-		{ 10422, new PositionInfo { X = 32.9f, Y = 28.8f } }, // Delta
-		{ 10423, new PositionInfo { X = 36.5f, Y = 25.9f } }, // Lambda
-		{ 10424, new PositionInfo { X = 32.1f, Y = 26.6f } }, // Level Tricker
-		{ 10427, new PositionInfo { X = 10.0f, Y = 30.0f } }, // Stellar Amphiptere
-		{ 10430, new PositionInfo { X = 14.4f, Y = 28.2f } }, // Stellar Brobinyak
-		{ 10435, new PositionInfo { X = 16.3f, Y = 14.1f } }, // Other One
-	};
+			// The Peaks
+			{ 05705, new List<PositionInfo>() { new() { X = 25.0f, Y = 11.0f, Radius = 150 } } }, // Crag Claw
+			{ 05701, new List<PositionInfo>() { new() { X = 18.7f, Y = 12.9f, Radius = 150 } } }, // Bloodglider
+			{ 05702, new List<PositionInfo>() { new() { X = 14.0f, Y = 08.0f, Radius = 150 } } }, // Fluturini
+			{ 05703, new List<PositionInfo>() { new() { X = 12.0f, Y = 08.0f, Radius = 150 } } }, // Gyr Abanian Hornbill
+			{ 05713, new List<PositionInfo>() { new() { X = 25.0f, Y = 33.0f, Radius = 150 } } }, // Highland Eruca
+			{ 05712, new List<PositionInfo>() { new() { X = 24.0f, Y = 29.0f, Radius = 150 } } }, // Jhammel
+			{ 05714, new List<PositionInfo>() { new() { X = 15.0f, Y = 27.0f, Radius = 150 } } }, // Kongamato
+			{ 05707, new List<PositionInfo>() { new() { X = 34.0f, Y = 09.0f, Radius = 150 } } }, // Marble Urolith
+			{ 05715, new List<PositionInfo>() { new() { X = 09.0f, Y = 26.0f, Radius = 150 } } }, // Pantera
+			{ 05708, new List<PositionInfo>() { new() { X = 24.0f, Y = 14.0f, Radius = 150 } } }, // Scarab Beetle
+			{ 05711, new List<PositionInfo>() { new() { X = 24.0f, Y = 24.0f, Radius = 150 } } }, // True Griffin
+
+			// The Ruby Sea
+			{ 05737, new List<PositionInfo>() { new() { X = 31.0f, Y = 35.0f, Radius = 150 } } }, // Bombfish
+			{ 05736, new List<PositionInfo>() { new() { X = 34.0f, Y = 05.0f, Radius = 150 } } }, // Coralshell
+			{ 05740, new List<PositionInfo>() { new() { X = 26.0f, Y = 30.0f, Radius = 150 } } }, // Flying Shark
+			{ 05742, new List<PositionInfo>() { new() { X = 23.0f, Y = 33.0f, Radius = 150 } } }, // Gasame
+			{ 05734, new List<PositionInfo>() { new() { X = 14.0f, Y = 10.0f, Radius = 150 } } }, // Gyuki
+			{ 05751, new List<PositionInfo>() { new() { X = 25.0f, Y = 25.0f, Radius = 150 } } }, // Naked Yumemi
+			{ 05743, new List<PositionInfo>() { new() { X = 07.0f, Y = 30.0f, Radius = 150 } } }, // Red Bukan
+			{ 05745, new List<PositionInfo>() { new() { X = 08.0f, Y = 28.0f, Radius = 150 } } }, // Red Honkan
+			{ 05744, new List<PositionInfo>() { new() { X = 09.5f, Y = 25.2f, Radius = 150 } } }, // Red Hyoe
+			{ 05738, new List<PositionInfo>() { new() { X = 33.0f, Y = 11.0f, Radius = 150 } } }, // Sea Serpent
+			{ 05739, new List<PositionInfo>() { new() { X = 26.0f, Y = 06.0f, Radius = 150 } } }, // Shiranui
+			{ 05746, new List<PositionInfo>() { new() { X = 07.0f, Y = 27.0f, Radius = 150 } } }, // Striped Ray
+			{ 05733, new List<PositionInfo>() { new() { X = 29.0f, Y = 37.0f, Radius = 150 } } }, // Tatsunoko
+			{ 05735, new List<PositionInfo>() { new() { X = 35.0f, Y = 21.0f, Radius = 150 } } }, // Unkiu
+			{ 05750, new List<PositionInfo>() { new() { X = 25.0f, Y = 25.0f, Radius = 150 } } }, // Yumemi
+
+			// Yanxia
+			{ 05761, new List<PositionInfo>() { new() { X = 18.0f, Y = 31.0f, Radius = 150 } } }, // Bi Fang
+			{ 05769, new List<PositionInfo>() { new() { X = 28.0f, Y = 08.0f, Radius = 150 } } }, // Ebisu Catfish
+			{ 05752, new List<PositionInfo>() { new() { X = 27.0f, Y = 34.0f, Radius = 150 } } }, // Lupin Bladehand
+			{ 05754, new List<PositionInfo>() { new() { X = 24.0f, Y = 32.0f, Radius = 150 } } }, // Lupin Bowhand
+			{ 05753, new List<PositionInfo>() { new() { X = 23.0f, Y = 28.0f, Radius = 150 } } }, // Lupin Spearhand
+			{ 05768, new List<PositionInfo>() { new() { X = 19.0f, Y = 11.0f, Radius = 150 } } }, // Magatsu Kiyofusa
+			{ 05763, new List<PositionInfo>() { new() { X = 33.0f, Y = 17.0f, Radius = 150 } } }, // Minobi
+			{ 05757, new List<PositionInfo>() { new() { X = 30.0f, Y = 23.0f, Radius = 150 } } }, // Rhino Beetle
+			{ 05765, new List<PositionInfo>() { new() { X = 30.0f, Y = 34.0f, Radius = 150 } } }, // Taoquan
+			{ 05755, new List<PositionInfo>() { new() { X = 24.0f, Y = 32.0f, Radius = 150 } } }, // Tenaga
+			{ 05764, new List<PositionInfo>() { new() { X = 23.0f, Y = 30.0f, Radius = 150 } } }, // Vanara
+			{ 05762, new List<PositionInfo>() { new() { X = 25.0f, Y = 26.0f, Radius = 150 } } }, // Water Serpent
+
+			// The Azim Steppe
+			{ 05785, new List<PositionInfo>() { new() { X = 15.0f, Y = 19.0f, Radius = 150 } } }, // Baras
+			{ 05788, new List<PositionInfo>() { new() { X = 17.0f, Y = 26.0f, Radius = 150 } } }, // Chaochu
+			{ 05777, new List<PositionInfo>() { new() { X = 23.0f, Y = 15.0f, Radius = 150 } } }, // Halgai
+			{ 05778, new List<PositionInfo>() { new() { X = 16.0f, Y = 11.0f, Radius = 150 } } }, // Khun Chuluu
+			{ 05781, new List<PositionInfo>() { new() { X = 31.0f, Y = 17.0f, Radius = 150 } } }, // Mammoth
+			{ 05783, new List<PositionInfo>() { new() { X = 12.0f, Y = 29.0f, Radius = 150 } } }, // Manzasiri
+			{ 05775, new List<PositionInfo>() { new() { X = 28.0f, Y = 13.0f, Radius = 150 } } }, // Matamata
+			{ 05782, new List<PositionInfo>() { new() { X = 09.0f, Y = 21.0f, Radius = 150 } } }, // Matanga
+			{ 05779, new List<PositionInfo>() { new() { X = 23.0f, Y = 10.0f, Radius = 150 } } }, // Muu Shuwuu
+			{ 05780, new List<PositionInfo>() { new() { X = 34.0f, Y = 18.0f, Radius = 150 } } }, // Purbol
+			{ 05776, new List<PositionInfo>() { new() { X = 26.0f, Y = 29.0f, Radius = 150 } } }, // Steppe Dhole
+			{ 05773, new List<PositionInfo>() { new() { X = 31.0f, Y = 32.0f, Radius = 150 } } }, // Steppe Dzo
+
+			// The Lochs
+			{ 05723, new List<PositionInfo>() { new() { X = 18.0f, Y = 32.0f, Radius = 150 } } }, // Abaddon
+			{ 05725, new List<PositionInfo>() { new() { X = 26.0f, Y = 11.0f, Radius = 150 } } }, // Abalathian Minotaur
+			{ 05720, new List<PositionInfo>() { new() { X = 25.0f, Y = 18.0f, Radius = 150 } } }, // Chelone
+			{ 05727, new List<PositionInfo>() { new() { X = 29.0f, Y = 15.0f, Radius = 150 } } }, // Creeping Edila
+			{ 05729, new List<PositionInfo>() { new() { X = 05.7f, Y = 26.7f, Radius = 150 } } }, // Dark Clay Beast
+			{ 05732, new List<PositionInfo>() { new() { X = 23.0f, Y = 10.0f, Radius = 150 } } }, // Guard Bhoot
+			{ 05716, new List<PositionInfo>() { new() { X = 08.0f, Y = 17.0f, Radius = 150 } } }, // Kaluk
+			{ 05724, new List<PositionInfo>() { new() { X = 16.0f, Y = 12.0f, Radius = 150 } } }, // Loch Leech
+			{ 05730, new List<PositionInfo>() { new() { X = 17.0f, Y = 16.0f, Radius = 150 } } }, // Loch Nanka
+			{ 05717, new List<PositionInfo>() { new() { X = 20.0f, Y = 18.0f, Radius = 150 } } }, // Phoebad
+			{ 05721, new List<PositionInfo>() { new() { X = 16.0f, Y = 21.0f, Radius = 150 } } }, // Soblyn
+			{ 05722, new List<PositionInfo>() { new() { X = 22.0f, Y = 23.0f, Radius = 150 } } }, // Salt Dhruva
+			{ 05728, new List<PositionInfo>() { new() { X = 17.0f, Y = 08.0f, Radius = 150 } } }, // Specter
+			{ 05726, new List<PositionInfo>() { new() { X = 25.0f, Y = 29.0f, Radius = 150 } } }, // Vepar
+			{ 05719, new List<PositionInfo>() { new() { X = 20.0f, Y = 25.0f, Radius = 150 } } }, // Yabby			
+
+
+			// Shadowbringers
+			// B Rank
+			// Lakeland
+			{ 08908, new List<PositionInfo>() {							// La Velue
+				new() { X = 23.0f, Y = 12.0f },
+				new() { X = 27.3f, Y = 15.4f },
+				new() { X = 29.4f, Y = 19.0f },
+				new() { X =  8.2f, Y = 22.7f },
+				new() { X = 12.0f, Y = 17.0f },
+				new() { X = 11.0f, Y = 12.0f },
+				new() { X = 14.0f, Y = 25.0f },
+				new() { X = 18.0f, Y = 23.0f },
+				new() { X = 19.6f, Y =  9.6f },
+			} },
+			{ 08909, new List<PositionInfo>() {							// Itzpapalotl
+				new() { X = 25.0f, Y = 24.0f },
+				new() { X = 30.0f, Y = 22.0f },
+				new() { X = 26.0f, Y = 36.0f },
+				new() { X = 27.0f, Y = 30.0f },
+				new() { X = 36.0f, Y = 27.0f },
+				new() { X = 36.0f, Y = 12.0f },
+				new() { X = 23.0f, Y = 30.0f },
+				new() { X = 35.0f, Y = 32.0f },
+				new() { X = 35.0f, Y = 16.0f },
+			} },
+			// Kholusia
+			{ 08913, new List<PositionInfo>() {							// Coquecigrue
+				new() { X = 17.0f, Y =  7.2f },
+				new() { X = 19.5f, Y = 10.5f },
+				new() { X = 21.3f, Y = 22.2f },
+				new() { X = 22.2f, Y = 13.7f },
+				new() { X = 22.5f, Y = 17.5f },
+				new() { X = 11.2f, Y = 18.4f },
+				new() { X = 26.7f, Y = 18.9f },
+				new() { X = 31.6f, Y = 20.2f },
+				new() { X = 25.2f, Y = 11.4f },
+				new() { X = 15.0f, Y = 15.7f },
+			} },
+			{ 08914, new List<PositionInfo>() {							// Indomitable
+				new() { X = 15.1f, Y = 24.2f },
+				new() { X = 20.8f, Y = 31.2f },
+				new() { X = 29.7f, Y = 30.2f },
+				new() { X = 24.7f, Y = 29.7f },
+				new() { X = 26.3f, Y = 24.2f },
+				new() { X = 34.4f, Y = 24.0f },
+				new() { X =  9.5f, Y = 25.3f },
+			} },
+			// Amh Araeng
+			{ 08903, new List<PositionInfo>() {							// Worm of the Well
+				new() { X = 12.0f, Y = 18.0f },
+				new() { X = 19.2f, Y = 15.8f },
+				new() { X = 22.5f, Y = 10.0f },
+				new() { X = 10.3f, Y = 12.2f },
+				new() { X = 16.7f, Y = 10.2f },
+				new() { X = 19.5f, Y = 25.2f },
+				new() { X = 16.0f, Y = 24.0f },
+				new() { X = 19.5f, Y = 29.0f },
+			} },
+			{ 08904, new List<PositionInfo>() {							// Juggler Hecatomb
+				new() { X = 28.6f, Y = 12.3f },
+				new() { X = 30.4f, Y = 34.9f },
+				new() { X = 32.8f, Y = 33.7f },
+				new() { X = 33.4f, Y = 22.1f },
+				new() { X = 23.2f, Y = 29.6f },
+				new() { X = 30.4f, Y = 13.7f },
+				new() { X = 28.3f, Y = 25.8f },
+				new() { X = 19.7f, Y = 36.5f },
+			} },
+			// Il Mheg
+			{ 08656, new List<PositionInfo>() {							// Domovoi
+				new() { X =  7.5f, Y = 22.7f },
+				new() { X = 10.0f, Y = 20.5f },
+				new() { X = 11.0f, Y = 15.6f },
+				new() { X = 19.0f, Y = 27.0f },
+				new() { X = 23.0f, Y = 33.0f },
+				new() { X = 24.9f, Y = 37.2f },
+				new() { X = 13.3f, Y = 34.2f },
+				new() { X =  8.0f, Y = 26.8f },
+				new() { X = 19.5f, Y = 35.2f },
+				new() { X = 22.0f, Y = 29.0f },
+				new() { X = 10.0f, Y = 30.8f },
+			} },
+			{ 08657, new List<PositionInfo>() {							// Vulpangue
+				new() { X = 19.8f, Y =  8.8f },
+				new() { X = 20.3f, Y =  8.2f },
+				new() { X = 25.3f, Y =  7.4f },
+				new() { X = 27.4f, Y = 18.7f },
+				new() { X = 29.0f, Y =  5.0f },
+				new() { X = 32.0f, Y = 13.9f },
+				new() { X = 34.0f, Y =  6.4f },
+			} },
+			// The Rak'tika Greatwood
+			{ 08893, new List<PositionInfo>() {							// Mindmaker
+				new() { X = 15.0f, Y = 30.1f },
+				new() { X = 17.5f, Y = 35.0f },
+				new() { X = 17.0f, Y = 24.0f },
+				new() { X =  8.5f, Y = 35.0f },
+				new() { X = 14.5f, Y = 22.3f },
+				new() { X = 10.2f, Y = 24.2f },
+				new() { X =  9.5f, Y = 18.6f },
+				new() { X = 12.5f, Y = 35.7f },
+			} },
+			{ 08894, new List<PositionInfo>() {							// Pachamama
+				new() { X = 26.1f, Y = 24.1f },
+				new() { X = 25.0f, Y = 30.0f },
+				new() { X = 33.0f, Y = 23.0f },
+				new() { X = 26.3f, Y = 14.9f },
+				new() { X = 22.0f, Y = 10.0f },
+				new() { X = 22.0f, Y = 13.3f },
+			} },
+			// The Tempest
+			{ 08899, new List<PositionInfo>() {							// Deacon
+				new() { X = 24.8f, Y = 24.9f },
+				new() { X = 28.7f, Y = 22.8f },
+				new() { X = 28.8f, Y =  8.1f },
+				new() { X = 29.2f, Y = 22.7f },
+				new() { X = 37.5f, Y = 16.0f },
+				new() { X = 30.9f, Y =  3.5f },
+				new() { X = 33.8f, Y = 21.4f },
+				new() { X = 36.3f, Y = 19.7f },
+				new() { X = 36.6f, Y = 11.2f },
+			} },
+			{ 08898, new List<PositionInfo>() {							// Gilshs Aath Swiftclaw
+				new() { X =  8.5f, Y =  8.6f },
+				new() { X = 11.0f, Y =  5.0f },
+				new() { X = 13.5f, Y = 17.2f },
+				new() { X = 15.6f, Y = 19.9f },
+				new() { X = 21.0f, Y =  7.5f },
+				new() { X = 25.1f, Y = 12.7f },
+				new() { X = 18.0f, Y = 13.0f },
+				new() { X = 15.8f, Y = 11.0f },
+				new() { X = 17.0f, Y = 13.0f },
+			} },
+
+			// Daily Targets
+			// Lakeland
+			{ 08498, new List<PositionInfo>() { new() { X = 19.0f, Y = 09.0f, Radius = 150 } } }, // Chiliad Cama
+			{ 08502, new List<PositionInfo>() { new() { X = 28.0f, Y = 23.2f, Radius = 150 } } }, // Violet Triffid
+			{ 08503, new List<PositionInfo>() { new() { X = 14.0f, Y = 16.5f, Radius = 150 } } }, // Gnole
+			{ 08504, new List<PositionInfo>() { new() { X = 24.4f, Y = 23.9f, Radius = 150 } } }, // Wetland Warg
+			{ 08505, new List<PositionInfo>() { new() { X = 33.2f, Y = 10.0f, Radius = 150 } } }, // White Gremlin
+			{ 08507, new List<PositionInfo>() { new() { X = 25.8f, Y = 23.3f, Radius = 150 } } }, // Hoptrap
+			{ 08508, new List<PositionInfo>() { new() { X = 28.5f, Y = 36.7f, Radius = 150 } } }, // Wolverine
+			{ 08511, new List<PositionInfo>() { new() { X = 11.3f, Y = 11.0f, Radius = 150 } } }, // Smilodon
+			{ 08514, new List<PositionInfo>() { new() { X = 34.2f, Y = 17.0f, Radius = 150 } } }, // Ya-te-veo
+			{ 08515, new List<PositionInfo>() { new() { X = 29.0f, Y = 17.6f, Radius = 150 } } }, // Proterosuchus
+			{ 08786, new List<PositionInfo>() { new() { X = 20.5f, Y = 25.3f, Radius = 150 } } }, // Lake Viper
+
+			// Kholusia
+			{ 08517, new List<PositionInfo>() { new() { X = 31.9f, Y = 18.9f, Radius = 150 } } }, // Ironbeard
+			{ 08518, new List<PositionInfo>() { new() { X = 36.4f, Y = 28.7f, Radius = 150 } } }, // Hobgoblin
+			{ 08520, new List<PositionInfo>() { new() { X = 17.0f, Y = 18.0f, Radius = 150 } } }, // Defective Talos
+			{ 08522, new List<PositionInfo>() { new() { X = 34.8f, Y = 10.5f, Radius = 150 } } }, // Sulfur Byrgen
+			{ 08523, new List<PositionInfo>() { new() { X = 35.4f, Y = 29.2f, Radius = 150 } } }, // Maultasche
+			{ 08524, new List<PositionInfo>() { new() { X = 14.3f, Y = 11.4f, Radius = 150 } } }, // Huldu
+			{ 08525, new List<PositionInfo>() { new() { X = 14.3f, Y = 27.1f, Radius = 150 } } }, // Island Rail
+			{ 08527, new List<PositionInfo>() { new() { X = 17.0f, Y = 11.0f, Radius = 150 } } }, // Cliffkite
+			{ 08528, new List<PositionInfo>() { new() { X = 27.1f, Y = 13.8f, Radius = 150 } } }, // Cliffmole
+			{ 08529, new List<PositionInfo>() { new() { X = 08.0f, Y = 18.0f, Radius = 150 } } }, // Scree Gnome
+			{ 08532, new List<PositionInfo>() { new() { X = 17.8f, Y = 26.5f, Radius = 150 } } }, // Wood Eyes
+			{ 08533, new List<PositionInfo>() { new() { X = 25.0f, Y = 23.5f, Radius = 150 } } }, // Island Wolf
+			{ 08534, new List<PositionInfo>() { new() { X = 10.1f, Y = 29.6f, Radius = 150 } } }, // Kholusian Bison
+			{ 08536, new List<PositionInfo>() { new() { X = 32.5f, Y = 26.2f, Radius = 150 } } }, // Whiptail
+			{ 08538, new List<PositionInfo>() { new() { X = 22.5f, Y = 09.6f, Radius = 150 } } }, // Highland Hyssop
+			{ 08539, new List<PositionInfo>() { new() { X = 19.9f, Y = 33.0f, Radius = 150 } } }, // Tragopan
+			{ 08540, new List<PositionInfo>() { new() { X = 13.0f, Y = 15.0f, Radius = 150 } } }, // Saichania
+			{ 08541, new List<PositionInfo>() { new() { X = 21.0f, Y = 08.7f, Radius = 150 } } }, // Gulgnu
+			{ 08542, new List<PositionInfo>() { new() { X = 21.6f, Y = 32.0f, Radius = 150 } } }, // Germinant
+
+			// Amh Araeng
+			{ 08544, new List<PositionInfo>() { new() { X = 11.4f, Y = 30.4f, Radius = 150 } } }, // Masterless Talos
+			{ 08545, new List<PositionInfo>() { new() { X = 19.1f, Y = 20.9f, Radius = 150 } } }, // Evil Weapon
+			{ 08547, new List<PositionInfo>() { new() { X = 30.4f, Y = 12.3f, Radius = 150 } } }, // Gigantender
+			{ 08550, new List<PositionInfo>() { new() { X = 29.4f, Y = 25.4f, Radius = 150 } } }, // Ancient Lizard
+			{ 08556, new List<PositionInfo>() { new() { X = 29.4f, Y = 21.7f, Radius = 150 } } }, // Sand Mole
+			{ 08557, new List<PositionInfo>() { new() { X = 12.7f, Y = 19.0f, Radius = 150 } } }, // Thistle Mole
+			{ 08558, new List<PositionInfo>() { new() { X = 30.9f, Y = 27.3f, Radius = 150 } } }, // Scissorjaws
+			{ 08559, new List<PositionInfo>() { new() { X = 21.5f, Y = 09.7f, Radius = 150 } } }, // Gnome
+			{ 08561, new List<PositionInfo>() { new() { X = 13.9f, Y = 18.2f, Radius = 150 } } }, // Debitage
+			{ 08562, new List<PositionInfo>() { new() { X = 27.1f, Y = 29.6f, Radius = 150 } } }, // Ghilman
+			{ 08563, new List<PositionInfo>() { new() { X = 25.0f, Y = 34.3f, Radius = 150 } } }, // Flame Zonure
+			{ 08565, new List<PositionInfo>() { new() { X = 15.2f, Y = 16.7f, Radius = 150 } } }, // Phorusrhacos
+			{ 08566, new List<PositionInfo>() { new() { X = 21.7f, Y = 09.8f, Radius = 150 } } }, // Desert Coyote
+			{ 08567, new List<PositionInfo>() { new() { X = 23.9f, Y = 31.8f, Radius = 150 } } }, // Molamander
+
+			// Il Mheg
+			{ 08155, new List<PositionInfo>() { new() { X = 08.4f, Y = 30.0f, Radius = 150 } } }, // Flower Basket
+			{ 08569, new List<PositionInfo>() { new() { X = 18.0f, Y = 31.0f, Radius = 150 } } }, // Echevore
+			{ 08574, new List<PositionInfo>() { new() { X = 31.0f, Y = 14.3f, Radius = 150 } } }, // Garden Porxie
+			{ 08575, new List<PositionInfo>() { new() { X = 19.9f, Y = 16.3f, Radius = 150 } } }, // Phooka
+			{ 08576, new List<PositionInfo>() { new() { X = 11.1f, Y = 26.0f, Radius = 150 } } }, // Etainmoth
+			{ 08577, new List<PositionInfo>() { new() { X = 29.4f, Y = 12.7f, Radius = 150 } } }, // Green Glider
+			{ 08578, new List<PositionInfo>() { new() { X = 21.0f, Y = 08.8f, Radius = 150 } } }, // Moss Fungus
+			{ 08581, new List<PositionInfo>() { new() { X = 07.8f, Y = 18.7f, Radius = 150 } } }, // Hawker
+			{ 08582, new List<PositionInfo>() { new() { X = 25.0f, Y = 11.0f, Radius = 150 } } }, // Rainbow Lorikeet
+			{ 08583, new List<PositionInfo>() { new() { X = 29.5f, Y = 11.4f, Radius = 150 } } }, // Tot Aevis
+			{ 08584, new List<PositionInfo>() { new() { X = 30.4f, Y = 10.6f, Radius = 150 } } }, // Rabbit's Tail
+			{ 08585, new List<PositionInfo>() { new() { X = 19.0f, Y = 32.0f, Radius = 150 } } }, // Rosebear
+			{ 08586, new List<PositionInfo>() { new() { X = 31.6f, Y = 06.4f, Radius = 150 } } }, // Garden Crocota
+			{ 08587, new List<PositionInfo>() { new() { X = 32.0f, Y = 05.8f, Radius = 150 } } }, // Werewood
+			{ 08590, new List<PositionInfo>() { new() { X = 09.4f, Y = 15.0f, Radius = 150 } } }, // Killer Bee
+
+			// The Rak'tika Greatwood
+			{ 08596, new List<PositionInfo>() { new() { X = 08.8f, Y = 35.6f, Radius = 150 } } }, // Tomatl
+			{ 08597, new List<PositionInfo>() { new() { X = 27.3f, Y = 25.6f, Radius = 150 } } }, // Forest Echo
+			{ 08598, new List<PositionInfo>() { new() { X = 25.1f, Y = 14.2f, Radius = 150 } } }, // Cracked Ronkan Doll
+			{ 08599, new List<PositionInfo>() { new() { X = 23.0f, Y = 14.0f, Radius = 150 } } }, // Cracked Ronkan Thorn
+			{ 08600, new List<PositionInfo>() { new() { X = 16.0f, Y = 32.0f, Radius = 150 } } }, // Vampire Vine
+			{ 08601, new List<PositionInfo>() { new() { X = 23.4f, Y = 07.6f, Radius = 150 } } }, // Greatwood Rail
+			{ 08603, new List<PositionInfo>() { new() { X = 29.4f, Y = 21.7f, Radius = 150 } } }, // Snapweed
+			{ 08604, new List<PositionInfo>() { new() { X = 12.0f, Y = 34.0f, Radius = 150 } } }, // Atrociraptor
+			{ 08606, new List<PositionInfo>() { new() { X = 27.7f, Y = 23.2f, Radius = 150 } } }, // Gizamaluk
+			{ 08609, new List<PositionInfo>() { new() { X = 16.9f, Y = 33.3f, Radius = 150 } } }, // Helm Beetle
+			{ 08610, new List<PositionInfo>() { new() { X = 34.1f, Y = 16.5f, Radius = 150 } } }, // Floor Mandrill
+			{ 08611, new List<PositionInfo>() { new() { X = 15.0f, Y = 19.4f, Radius = 150 } } }, // Wild Swine
+			{ 08612, new List<PositionInfo>() { new() { X = 24.9f, Y = 30.2f, Radius = 150 } } }, // Caracal
+			{ 08614, new List<PositionInfo>() { new() { X = 25.0f, Y = 07.2f, Radius = 150 } } }, // Woodbat
+			{ 08616, new List<PositionInfo>() { new() { X = 27.9f, Y = 21.2f, Radius = 150 } } }, // Tarichuk
+			{ 08789, new List<PositionInfo>() { new() { X = 21.1f, Y = 13.2f, Radius = 150 } } }, // Cracked Ronkan Vessel
+
+			// The Tempest
+			{ 08618, new List<PositionInfo>() { new() { X = 28.6f, Y = 06.2f, Radius = 150 } } }, // Clinoid
+			{ 08619, new List<PositionInfo>() { new() { X = 28.2f, Y = 18.3f, Radius = 150 } } }, // Dagon
+			{ 08621, new List<PositionInfo>() { new() { X = 22.6f, Y = 31.7f, Radius = 150 } } }, // Cubus
+			{ 08622, new List<PositionInfo>() { new() { X = 25.1f, Y = 18.6f, Radius = 150 } } }, // Sea Anemone
+			{ 08623, new List<PositionInfo>() { new() { X = 32.1f, Y = 11.7f, Radius = 150 } } }, // Amphisbaena
+			{ 08625, new List<PositionInfo>() { new() { X = 32.5f, Y = 21.5f, Radius = 150 } } }, // Morgawr
+			{ 08626, new List<PositionInfo>() { new() { X = 36.6f, Y = 16.6f, Radius = 150 } } }, // Trilobite
+			{ 08629, new List<PositionInfo>() { new() { X = 27.7f, Y = 08.7f, Radius = 150 } } }, // Sea Gelatin
+			{ 08630, new List<PositionInfo>() { new() { X = 29.0f, Y = 21.0f, Radius = 150 } } }, // Tempest Swallow
+			{ 08631, new List<PositionInfo>() { new() { X = 35.8f, Y = 07.2f, Radius = 150 } } }, // Blue Swimmer
+
+			// Endwalker
+			// B Rank
+			// Labyrinthos
+			{ 10636, new List<PositionInfo>() {							// Ü-u-ü-u
+				new() { X =  5.9f, Y = 33.1f },
+				new() { X = 12.1f, Y = 35.4f },
+				new() { X = 10.6f, Y = 18.8f },
+				new() { X = 16.4f, Y = 17.0f },
+				new() { X = 19.7f, Y = 38.4f },
+				new() { X = 24.9f, Y = 25.4f },
+			} },
+			{ 10635, new List<PositionInfo>() {							// Green Archon
+				new() { X = 17.2f, Y =  8.9f },
+				new() { X = 30.0f, Y =  8.1f },
+				new() { X = 34.0f, Y = 13.6f },
+				new() { X = 32.9f, Y = 25.8f },
+			} },
+			// Thavnair
+			{ 10638, new List<PositionInfo>() {							// Iravati
+				new() { X = 18.3f, Y = 23.5f },
+				new() { X = 19.9f, Y = 31.0f },
+				new() { X = 26.4f, Y = 20.6f },
+				new() { X = 27.5f, Y = 25.1f },
+				new() { X = 32.8f, Y = 20.5f },
+			} },
+			{ 10637, new List<PositionInfo>() {							// Vajrakumara
+				new() { X = 14.6f, Y = 11.7f },
+				new() { X = 17.4f, Y = 16.2f },
+				new() { X = 18.2f, Y = 11.7f },
+				new() { X = 29.6f, Y = 13.2f },
+			} },
+			// Garlemald
+			{ 10640, new List<PositionInfo>() {							// Emperor's Rose
+				new() { X = 23.0f, Y = 25.7f },
+				new() { X = 27.5f, Y = 33.8f },
+				new() { X = 29.0f, Y = 20.8f },
+				new() { X = 31.8f, Y = 32.8f },
+				new() { X = 33.1f, Y = 22.2f },
+			} },
+			{ 10639, new List<PositionInfo>() {							// Warmonger
+				new() { X =  9.5f, Y = 11.5f },
+				new() { X = 11.6f, Y = 12.9f },
+				new() { X = 12.0f, Y = 16.6f },
+				new() { X = 15.6f, Y = 19.8f },
+			} },
+			// Mare Lamentorum
+			{ 10642, new List<PositionInfo>() {							// Genesis Rock
+				new() { X = 16.4f, Y = 28.7f },
+				new() { X = 21.3f, Y = 34.7f },
+				new() { X = 24.4f, Y = 33.4f },
+				new() { X = 30.2f, Y = 29.7f },
+				new() { X = 36.5f, Y = 26.9f },
+			} },
+			{ 10641, new List<PositionInfo>() {							// Daphnia Magna
+				new() { X = 10.4f, Y = 24.0f },
+				new() { X = 17.4f, Y = 25.1f },
+				new() { X = 18.1f, Y = 21.4f },
+				new() { X = 24.0f, Y = 24.0f },
+				new() { X = 28.0f, Y = 26.8f },
+			} },
+			// Elpis
+			{ 10644, new List<PositionInfo>() {							// Shockmaw
+				new() { X =  7.0f, Y = 28.9f },
+				new() { X = 12.8f, Y = 32.3f },
+				new() { X = 17.9f, Y = 30.3f },
+				new() { X = 19.0f, Y = 24.6f },
+				new() { X = 29.5f, Y = 27.6f },
+			} },
+			{ 10643, new List<PositionInfo>() {							// Yumcax
+				new() { X = 12.9f, Y =  9.4f },
+				new() { X = 21.5f, Y =  5.7f },
+				new() { X = 21.2f, Y = 13.2f },
+				new() { X = 32.5f, Y = 18.3f },
+				new() { X = 34.5f, Y = 14.0f },
+				new() { X = 34.1f, Y = 10.8f },
+			} },
+			// Ultima Thule
+			{ 10646, new List<PositionInfo>() {							// Oskh Rhei
+				new() { X = 14.8f, Y = 36.0f },
+				new() { X = 16.3f, Y = 26.3f },
+				new() { X = 17.4f, Y = 30.3f },
+				new() { X = 21.6f, Y = 34.3f },
+			} },
+			{ 10645, new List<PositionInfo>() {							// Level Cheater
+				new() { X =  8.1f, Y = 20.4f },
+				new() { X = 11.9f, Y = 21.9f },
+				new() { X = 13.2f, Y = 10.4f },
+				new() { X = 19.1f, Y =  9.8f },
+				new() { X = 27.7f, Y = 11.9f },
+			} },
+
+			// Daily Targets
+			// Labyrinthos
+			{ 10668, new List<PositionInfo>() { new() { X = 28.8f, Y = 08.8f, Radius = 150 } } }, // Troll
+			{ 10669, new List<PositionInfo>() { new() { X = 31.0f, Y = 25.5f, Radius = 150 } } }, // Genomos
+			{ 10670, new List<PositionInfo>() { new() { X = 15.0f, Y = 06.5f, Radius = 150 } } }, // Caribou
+			{ 10672, new List<PositionInfo>() { new() { X = 32.0f, Y = 08.8f, Radius = 150 } } }, // Limascabra
+			{ 10673, new List<PositionInfo>() { new() { X = 21.5f, Y = 13.5f, Radius = 150 } } }, // Luncheon Toad
+			{ 10674, new List<PositionInfo>() { new() { X = 17.0f, Y = 12.0f, Radius = 150 } } }, // Yakow
+			{ 10677, new List<PositionInfo>() { new() { X = 34.0f, Y = 15.0f, Radius = 150 } } }, // Labyrinth Screamer
+			{ 10678, new List<PositionInfo>() { new() { X = 24.0f, Y = 10.7f, Radius = 150 } } }, // Northern Snapweed
+			{ 10679, new List<PositionInfo>() { new() { X = 26.0f, Y = 14.5f, Radius = 150 } } }, // Pephredo
+			{ 10683, new List<PositionInfo>() { new() { X = 37.5f, Y = 19.5f, Radius = 150 } } }, // Mythrilcap
+
+			// Thavnair
+			{ 10697, new List<PositionInfo>() { new() { X = 19.0f, Y = 23.9f, Radius = 150 } } }, // Pisaca
+			{ 10698, new List<PositionInfo>() { new() { X = 13.8f, Y = 18.5f, Radius = 150 } } }, // Vajralangula
+			{ 10699, new List<PositionInfo>() { new() { X = 19.2f, Y = 32.6f, Radius = 150 } } }, // Kacchapa
+			{ 10700, new List<PositionInfo>() { new() { X = 18.4f, Y = 26.7f, Radius = 150 } } }, // Hamsa
+			{ 10701, new List<PositionInfo>() { new() { X = 29.1f, Y = 12.2f, Radius = 150 } } }, // Asvattha
+			{ 10702, new List<PositionInfo>() { new() { X = 27.1f, Y = 27.8f, Radius = 150 } } }, // Guhasaya
+			{ 10703, new List<PositionInfo>() { new() { X = 27.0f, Y = 17.4f, Radius = 150 } } }, // Bhujamga
+			{ 10704, new List<PositionInfo>() { new() { X = 17.6f, Y = 17.8f, Radius = 150 } } }, // Sotormurg
+			{ 10705, new List<PositionInfo>() { new() { X = 22.7f, Y = 30.4f, Radius = 150 } } }, // Gaja
+			{ 10706, new List<PositionInfo>() { new() { X = 19.1f, Y = 11.7f, Radius = 150 } } }, // Thavnairian Jhammel
+			{ 10707, new List<PositionInfo>() { new() { X = 25.9f, Y = 19.0f, Radius = 150 } } }, // Ufiti
+			{ 10709, new List<PositionInfo>() { new() { X = 09.2f, Y = 12.8f, Radius = 150 } } }, // Chamrosh
+			{ 10711, new List<PositionInfo>() { new() { X = 16.1f, Y = 09.2f, Radius = 150 } } }, // Starmite
+			{ 10712, new List<PositionInfo>() { new() { X = 14.3f, Y = 12.7f, Radius = 150 } } }, // Manjusaka
+			{ 10713, new List<PositionInfo>() { new() { X = 23.3f, Y = 19.9f, Radius = 150 } } }, // Odqan
+			{ 10715, new List<PositionInfo>() { new() { X = 13.4f, Y = 28.5f, Radius = 150 } } }, // Akyaali Crab
+			{ 10716, new List<PositionInfo>() { new() { X = 08.2f, Y = 16.2f, Radius = 150 } } }, // Valras
+
+			// Garlemald
+			{ 10648, new List<PositionInfo>() { new() { X = 18.8f, Y = 09.8f, Radius = 150 } } }, // Automated Satellite
+			{ 10649, new List<PositionInfo>() { new() { X = 25.5f, Y = 17.5f, Radius = 150 } } }, // Automated Death Machine
+			{ 10650, new List<PositionInfo>() { new() { X = 15.5f, Y = 19.5f, Radius = 150 } } }, // Automated Cavalry
+			{ 10651, new List<PositionInfo>() { new() { X = 21.8f, Y = 17.4f, Radius = 150 } } }, // Automated Bit
+			{ 10652, new List<PositionInfo>() { new() { X = 15.7f, Y = 09.8f, Radius = 150 } } }, // Automated Roader
+			{ 10653, new List<PositionInfo>() { new() { X = 29.5f, Y = 13.7f, Radius = 150 } } }, // Automated Slasher
+			{ 10654, new List<PositionInfo>() { new() { X = 24.3f, Y = 14.9f, Radius = 150 } } }, // Automated Colossus
+			{ 10655, new List<PositionInfo>() { new() { X = 12.9f, Y = 11.7f, Radius = 150 } } }, // Automated Avenger
+			{ 10656, new List<PositionInfo>() { new() { X = 29.6f, Y = 30.3f, Radius = 150 } } }, // Almasty
+			{ 10657, new List<PositionInfo>() { new() { X = 14.6f, Y = 26.1f, Radius = 150 } } }, // Eblan Bear
+			{ 10658, new List<PositionInfo>() { new() { X = 31.3f, Y = 17.4f, Radius = 150 } } }, // Eblan Icetrap
+			{ 10659, new List<PositionInfo>() { new() { X = 19.8f, Y = 29.1f, Radius = 150 } } }, // Ovibos
+			{ 10660, new List<PositionInfo>() { new() { X = 22.3f, Y = 24.9f, Radius = 150 } } }, // Jotunn
+			{ 10661, new List<PositionInfo>() { new() { X = 28.4f, Y = 33.0f, Radius = 150 } } }, // Ceruleum Zoblyn
+			{ 10662, new List<PositionInfo>() { new() { X = 25.4f, Y = 31.5f, Radius = 150 } } }, // Ilsabardian Tursus
+			{ 10663, new List<PositionInfo>() { new() { X = 18.7f, Y = 24.8f, Radius = 150 } } }, // Canis Lupinus
+			{ 10664, new List<PositionInfo>() { new() { X = 26.1f, Y = 26.5f, Radius = 150 } } }, // Overgrown Rose
+
+			// Mare Lamentorum
+			{ 10458, new List<PositionInfo>() { new() { X = 23.9f, Y = 20.0f, Radius = 150 } } }, // Daphnia
+			{ 10459, new List<PositionInfo>() { new() { X = 23.7f, Y = 20.3f, Radius = 150 } } }, // Osculator
+			{ 10460, new List<PositionInfo>() { new() { X = 08.6f, Y = 35.5f, Radius = 150 } } }, // Sweeper
+			{ 10461, new List<PositionInfo>() { new() { X = 27.3f, Y = 26.0f, Radius = 150 } } }, // Wanderer
+			{ 10462, new List<PositionInfo>() { new() { X = 31.1f, Y = 32.2f, Radius = 150 } } }, // Weeper
+			{ 10463, new List<PositionInfo>() { new() { X = 19.8f, Y = 22.5f, Radius = 150 } } }, // Thinker
+			{ 10464, new List<PositionInfo>() { new() { X = 26.0f, Y = 34.0f, Radius = 150 } } }, // Regolith
+			{ 10465, new List<PositionInfo>() { new() { X = 21.4f, Y = 32.2f, Radius = 150 } } }, // Trimmer
+			{ 10467, new List<PositionInfo>() { new() { X = 12.0f, Y = 36.7f, Radius = 150 } } }, // Panopt
+			{ 10468, new List<PositionInfo>() { new() { X = 11.5f, Y = 22.3f, Radius = 150 } } }, // Dynamite
+			{ 10469, new List<PositionInfo>() { new() { X = 16.7f, Y = 31.8f, Radius = 150 } } }, // Armalcolite
+			{ 10470, new List<PositionInfo>() { new() { X = 12.9f, Y = 09.6f, Radius = 150 } } }, // Caretaker
+			{ 10471, new List<PositionInfo>() { new() { X = 16.1f, Y = 24.9f, Radius = 150 } } }, // Mousse
+			{ 10473, new List<PositionInfo>() { new() { X = 31.2f, Y = 27.0f, Radius = 150 } } }, // Downfall Alarum
+			{ 10474, new List<PositionInfo>() { new() { X = 33.6f, Y = 26.2f, Radius = 150 } } }, // Downfall Droid
+			{ 10475, new List<PositionInfo>() { new() { X = 34.5f, Y = 28.0f, Radius = 150 } } }, // Downfall Hunter
+			{ 10476, new List<PositionInfo>() { new() { X = 13.0f, Y = 10.0f, Radius = 150 } } }, // Supporter
+			{ 10477, new List<PositionInfo>() { new() { X = 30.1f, Y = 11.0f, Radius = 150 } } }, // Scraper
+
+			// Elpis
+			{ 10590, new List<PositionInfo>() { new() { X = 25.7f, Y = 33.9f, Radius = 150 } } }, // Ophion
+			{ 10591, new List<PositionInfo>() { new() { X = 16.5f, Y = 29.9f, Radius = 150 } } }, // Yggdreant
+			{ 10592, new List<PositionInfo>() { new() { X = 22.6f, Y = 20.0f, Radius = 150 } } }, // Okyupete
+			{ 10594, new List<PositionInfo>() { new() { X = 12.4f, Y = 31.8f, Radius = 150 } } }, // Gryps
+			{ 10595, new List<PositionInfo>() { new() { X = 26.6f, Y = 29.7f, Radius = 150 } } }, // Monoceros
+			{ 10596, new List<PositionInfo>() { new() { X = 10.1f, Y = 14.1f, Radius = 150 } } }, // Pegasos
+			{ 10597, new List<PositionInfo>() { new() { X = 28.7f, Y = 25.6f, Radius = 150 } } }, // Bird of Elpis
+			{ 10599, new List<PositionInfo>() { new() { X = 33.4f, Y = 14.3f, Radius = 150 } } }, // Hippe
+			{ 10600, new List<PositionInfo>() { new() { X = 14.1f, Y = 09.9f, Radius = 150 } } }, // Harpuia
+			{ 10601, new List<PositionInfo>() { new() { X = 25.0f, Y = 10.0f, Radius = 150 } } }, // Morbol Marquis
+			{ 10602, new List<PositionInfo>() { new() { X = 29.2f, Y = 09.3f, Radius = 150 } } }, // Akantha
+			{ 10603, new List<PositionInfo>() { new() { X = 24.4f, Y = 14.3f, Radius = 150 } } }, // Lykopersikon
+			{ 10606, new List<PositionInfo>() { new() { X = 21.5f, Y = 06.3f, Radius = 150 } } }, // Lotis
+			{ 10607, new List<PositionInfo>() { new() { X = 10.2f, Y = 34.6f, Radius = 150 } } }, // Phanopsyche
+			{ 10608, new List<PositionInfo>() { new() { X = 12.9f, Y = 23.4f, Radius = 150 } } }, // Melanion
+			{ 10609, new List<PositionInfo>() { new() { X = 12.9f, Y = 08.7f, Radius = 150 } } }, // Ophiotauros
+			{ 10610, new List<PositionInfo>() { new() { X = 13.3f, Y = 15.7f, Radius = 150 } } }, // Elpis Minotaur
+			{ 10611, new List<PositionInfo>() { new() { X = 30.7f, Y = 17.1f, Radius = 150 } } }, // Remora
+
+			// Ultima Thule
+			{ 10419, new List<PositionInfo>() { new() { X = 30.1f, Y = 25.9f, Radius = 150 } } }, // Broken Omicron
+			{ 10420, new List<PositionInfo>() { new() { X = 19.3f, Y = 11.8f, Radius = 150 } } }, // Drifting Ea
+			{ 10421, new List<PositionInfo>() { new() { X = 34.8f, Y = 28.8f, Radius = 150 } } }, // Beta
+			{ 10422, new List<PositionInfo>() { new() { X = 32.9f, Y = 28.8f, Radius = 150 } } }, // Delta
+			{ 10423, new List<PositionInfo>() { new() { X = 36.5f, Y = 25.9f, Radius = 150 } } }, // Lambda
+			{ 10424, new List<PositionInfo>() { new() { X = 32.1f, Y = 26.6f, Radius = 150 } } }, // Level Tricker
+			{ 10427, new List<PositionInfo>() { new() { X = 10.0f, Y = 30.0f, Radius = 150 } } }, // Stellar Amphiptere
+			{ 10430, new List<PositionInfo>() { new() { X = 14.4f, Y = 28.2f, Radius = 150 } } }, // Stellar Brobinyak
+			{ 10435, new List<PositionInfo>() { new() { X = 16.3f, Y = 14.1f, Radius = 150 } } }, // Other One
+		};
 
 	public enum OpenType {
 		None, // Just place marker
@@ -473,18 +1809,37 @@ public static class Location {
 			return;
 		}
 
-		(int X, int Y) pos = MapToWorldCoordinates(Database[mobHuntId].Coordinate, mapId);
-
 		map->IsFlagMarkerSet = 0;
-		map->SetFlagMapMarker(territoryType, mapId, pos.X, pos.Y, 60004);
 
 		switch (openType) {
 			case OpenType.None:
 				break;
 			case OpenType.ShowOpen:
 				map->AgentInterface.Hide();
-				map->AddGatheringTempMarker(pos.X, pos.Y, 150, 60004, 4, mobHuntName);
-				map->OpenMap(mapId, territoryType, mobHuntName, MapType.GatheringLog);
+				// If mob is part of a FATE, show that instead
+				if (Database[mobHuntId].Count == 1 && Database[mobHuntId][0].Fate != 0) {
+					(int X, int Y) pos = MapToWorldCoordinates(Database[mobHuntId][0].Coordinate, mapId);
+					map->AddGatheringTempMarker(pos.X, pos.Y, Database[mobHuntId][0].Radius, 60004, 4, mobHuntName);
+					map->OpenMap(mapId, territoryType, $"FATE: {Service.DataManager.GetExcelSheet<Fate>()!.GetRow(Database[mobHuntId][0].Fate)!.Name}", MapType.GatheringLog);
+					break;
+				}
+
+				// If target is not elite
+				if (Database[mobHuntId].Count == 1) {
+					(int X, int Y) pos = MapToWorldCoordinates(Database[mobHuntId][0].Coordinate, mapId);
+					map->AddGatheringTempMarker(pos.X, pos.Y, Database[mobHuntId][0].Radius, 60004, 4, mobHuntName);
+					map->OpenMap(mapId, territoryType, mobHuntName, MapType.GatheringLog);
+					break;
+				}
+
+				foreach (PositionInfo location in Database[mobHuntId]) {
+					Service.PluginLog.Debug($"({location.X}, {location.Y})");
+					(int X, int Y) pos = MapToWorldCoordinates(location.Coordinate, mapId);
+					if (!map->AddMapMarker(new Vector3 { X = pos.X, Y = 0, Z = pos.Y }, 60004)) {
+						Service.PluginLog.Debug("Unable to place all markers on map");
+					}
+					map->OpenMap(mapId, territoryType);
+				}
 				break;
 			case OpenType.MarkerOpen:
 				map->AgentInterface.Hide();
@@ -530,7 +1885,7 @@ public static class Location {
 			.Select(
 				x => new {
 					distance = Vector2.DistanceSquared(
-						Database[mobHuntId].Coordinate,
+						Database[mobHuntId][0].Coordinate,
 						ConvertPixelPositionToMapCoordinate(x.X, x.Y, mapRow.SizeFactor)),
 					rowId = x.DataKey
 				})

--- a/HuntBuddy/Plugin.cs
+++ b/HuntBuddy/Plugin.cs
@@ -164,7 +164,7 @@ public class Plugin: IDalamudPlugin {
 							.OrderBy(entry =>
 								entry.IsEliteMark
 									? float.MaxValue
-									: Vector2.Distance(Location.Database[entry.MobHuntId].Coordinate, playerVec2))
+									: Vector2.Distance(Location.Database[entry.MobHuntId][0].Coordinate, playerVec2))
 							.FirstOrDefault();
 						if (chosen == null) {
 							Service.PluginLog.Information("No marks in current zone, looking in current expansion");

--- a/HuntBuddy/Windows/LocalHuntsWindow.cs
+++ b/HuntBuddy/Windows/LocalHuntsWindow.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 
 using Dalamud.Interface;
@@ -130,6 +131,10 @@ public class LocalHuntsWindow: Window {
 			}
 
 			ImGui.Text($"{mobHuntEntry.Name} ({currentKills}/{mobHuntEntry.NeededKills})");
+
+			if (Location.Database.TryGetValue(mobHuntEntry.MobHuntId, out List<Location.PositionInfo>? value) && value[0].Fate != 0) {
+				ImGui.Text($"FATE: {Service.DataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets2.Fate>()!.GetRow(value[0].Fate)!.Name}");
+			}
 
 			if (!Plugin.Instance.Configuration.ShowLocalHuntIcons) {
 				continue;


### PR DESCRIPTION
I know you have explicitly said many times you weren't interested in doing a feature like this, but I figured I'd at least open this PR to gauge interest. If this is not something you are interested in, you won't hurt my feelings if you shoot it down outright.

This PR attempts to add additional support for ARR and B rank hunts by:

1. Changing the location database to have a List of positions for each target, instead of just one.
2. Adding a Radius to PositionInfo with a default of 50 so that targets can set their own radius.
3. Adding an optional Fate parameter to PositionInfo.
4. Adding the locations for ARR B ranks.
5. Some ARR Daily Targets only spawn with FATEs. I added the FATEs those targets spawn with.
6. When you click on "Show hunt area on the map" for B ranks, it should populate the map with markers for each of the locations. Possibly this feature could be expanded by removing and resetting the map once the mark has been defeated.
7. For those targets that only spawn with FATEs, I added a text indicator in LocalHuntWindow so that is more obvious.
![image](https://github.com/SheepGoMeh/HuntBuddy/assets/7546899/1e66520f-6b30-41d3-a3a3-d8fcf22cd7a9)

EDIT: If this is something you are indeed interested in, I would prefer to be able to test again next week. I did all my B ranks this week and I think everything was working, but I would prefer to test again next week to make sure I didn't overlook anything obvious.