### PR TITLE
Hide the local hunts window while in cutscenes

### DIFF
--- a/HuntBuddy/Service.cs
+++ b/HuntBuddy/Service.cs
@@ -65,4 +65,10 @@ public class Service {
 		get;
 		set;
 	} = null!;
+
+	[PluginService]
+	public static ICondition Condition {
+		get;
+		set;
+	} = null!;
 }

--- a/HuntBuddy/Windows/LocalHuntsWindow.cs
+++ b/HuntBuddy/Windows/LocalHuntsWindow.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Numerics;
 
+using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Interface;
 using Dalamud.Interface.Windowing;
 
@@ -47,6 +48,7 @@ public class LocalHuntsWindow: Window {
 	}
 
 	public override unsafe bool DrawConditions() => Plugin.Instance.Configuration.ShowLocalHunts
+		&& !Service.Condition.Any(ConditionFlag.WatchingCutscene, ConditionFlag.OccupiedInCutSceneEvent)
 		&& !Plugin.Instance.CurrentAreaMobHuntEntries.IsEmpty
 		&& Plugin.Instance.CurrentAreaMobHuntEntries
 			.Count(x => Plugin.Instance.MobHuntStruct->CurrentKills[x.CurrentKillsOffset] == x.NeededKills) != Plugin.Instance.CurrentAreaMobHuntEntries.Count;


### PR DESCRIPTION
Minimal changes; an `ICondition` service is added, to be referenced in the draw conditions for the local hunt marks window, in order to hide it while viewing cutscenes.